### PR TITLE
Add profile link in timeline view

### DIFF
--- a/src/app/pages/timeline/timeline.component.html
+++ b/src/app/pages/timeline/timeline.component.html
@@ -1135,6 +1135,11 @@
                           href="tel:{{client.client.phone}}"
                           title="{{client.client.phone}}">
                         </vex-icon>
+                        <button mat-icon-button
+                                [routerLink]="'/clients/update/' + client.client.id"
+                                matTooltip="View client">
+                          <mat-icon svgIcon="mat:person"></mat-icon>
+                        </button>
                       </div>
                       <div>
                         <span style="float:left;cursor:pointer"


### PR DESCRIPTION
## Summary
- add button linking to client profile in timeline view

## Testing
- `npm test` *(fails: cannot find module 'karma-coverage-istanbul-reporter')*

------
https://chatgpt.com/codex/tasks/task_e_68827ab1ba60832087e5124ad7773a33