### PR TITLE
Enable closing of calendar and course modals

### DIFF
--- a/src/app/pages/calendar/calendar.component.ts
+++ b/src/app/pages/calendar/calendar.component.ts
@@ -131,8 +131,11 @@ export class CalendarComponent {
 
   handleEvent(action: string, event: CalendarEvent): void {
     const dialogRef = this.dialog.open(CalendarEditComponent, {
-      data: event
+      data: event,
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/src/app/pages/courses-v2/pendiente/course-detail-modal/course-detail-modal.component.ts
+++ b/src/app/pages/courses-v2/pendiente/course-detail-modal/course-detail-modal.component.ts
@@ -259,8 +259,11 @@ export class CourseDetailModalComponent implements OnInit {
       height: '1200px',
       maxWidth: '90vw',  // Asegurarse de que no haya un ancho máximo
       panelClass: 'full-screen-dialog',  // Si necesitas estilos adicionales
-      data: { id: this.id }
+      data: { id: this.id },
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((data: any) => {
       if (data) {

--- a/src/app/pages/courses/course-detail-modal/course-detail-modal.component.ts
+++ b/src/app/pages/courses/course-detail-modal/course-detail-modal.component.ts
@@ -261,8 +261,11 @@ export class CourseDetailModalComponent implements OnInit {
       height: '1200px',
       maxWidth: '90vw',  // Asegurarse de que no haya un ancho máximo
       panelClass: 'full-screen-dialog',  // Si necesitas estilos adicionales
-      data: {id: this.id}
+      data: {id: this.id},
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((data: any) => {
       if (data) {

--- a/src/app/pages/monitors/monitor-detail/calendar/calendar.component.ts
+++ b/src/app/pages/monitors/monitor-detail/calendar/calendar.component.ts
@@ -143,8 +143,11 @@ export class CalendarComponent implements OnInit {
 
   handleEvent(action: string, event: CalendarEvent): void {
     const dialogRef = this.dialog.open(CalendarEditComponent, {
-      data: event
+      data: event,
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
@@ -159,8 +162,11 @@ export class CalendarComponent implements OnInit {
 
   handleUpdateEvent(action: string, event: CalendarEvent): void {
     const dialogRef = this.dialog.open(CalendarEditComponent, {
-      data: event
+      data: event,
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
@@ -201,8 +207,11 @@ export class CalendarComponent implements OnInit {
 
   handleDbClickEvent(action: string, event: any): void {
     const dialogRef = this.dialog.open(CalendarEditComponent, {
-      data: event
+      data: event,
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/src/app/pages/monitors/monitor-detail/monitor-detail.component.ts
+++ b/src/app/pages/monitors/monitor-detail/monitor-detail.component.ts
@@ -2008,8 +2008,11 @@ export class MonitorDetailComponent {
       panelClass: 'full-screen-dialog',
       data: {
         id: this.taskDetailTimeline.course.id
-      }
+      },
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) { }
@@ -2073,8 +2076,11 @@ export class MonitorDetailComponent {
         date_param: dateInfo.date_format,
         hour_start: dateInfo.hour,
         monitor: this.defaults
-      }
+      },
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/src/app/pages/timeline/timeline.component.ts
+++ b/src/app/pages/timeline/timeline.component.ts
@@ -1844,8 +1844,11 @@ export class TimelineComponent implements OnInit, OnDestroy {
         date_param: dateInfo.date_format,
         hour_start: dateInfo.hour,
         monitor: this.allMonitorsTimeline.find((m) => m.id === monitor_id)
-      }
+      },
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
@@ -1973,8 +1976,11 @@ export class TimelineComponent implements OnInit, OnDestroy {
       data: {
         block_general: true,
         date_param: currentDateFormat,
-      }
+      },
+      disableClose: false
     });
+
+    dialogRef.backdropClick().subscribe(() => dialogRef.close());
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {


### PR DESCRIPTION
## Summary
- allow closing `CalendarEditComponent` by clicking the backdrop
- allow closing course edit dialogs by clicking outside
- close dialogs on backdrop click for calendar and course components

## Testing
- `npm test --silent` *(fails: Cannot find module 'karma-coverage-istanbul-reporter')*

------
https://chatgpt.com/codex/tasks/task_e_68827eae619c8320b32d90ca5ac75e0f