### PR TITLE
Update monitor transfer workflow

### DIFF
--- a/src/app/pages/timeline/timeline.component.html
+++ b/src/app/pages/timeline/timeline.component.html
@@ -1051,8 +1051,9 @@
               </div>
               <mat-form-field appearance="outline" class="flex-auto"
                               style="width: 100%;" *ngIf="!loadingMonitors">
-                <mat-select placeholder="{{'new_monitor' | translate}}"
-                            [(ngModel)]="editedMonitor">
+                <mat-select placeholder="{{'new_monitor' | translate}}" required
+                            #monitorSelect="ngModel"
+                            [(ngModel)]="editedMonitor" [disabled]="savingMonitor">
                   <mat-option *ngIf="taskDetail.monitor_id"
                               [value]="nullMonitor">
                     {{'no_monitor_choose' | translate}}
@@ -1060,19 +1061,24 @@
                   <ng-container *ngFor="let monitor of monitorsForm">
                     <mat-option *ngIf="monitor.id != taskDetail.monitor_id"
                                 [value]="monitor">
-                      {{ monitor.first_name }} {{ monitor.last_name }}
+                      {{ monitor.first_name }} {{ monitor.last_name }} -
+                      {{ getLanguageById(monitor.language1_id) }}
                     </mat-option>
                   </ng-container>
                 </mat-select>
+                <mat-error *ngIf="saveMonitorAttempted && !editedMonitor">
+                  {{ 'required' | translate }}
+                </mat-error>
               </mat-form-field>
 
               <div class="actions flex items-center justify-end gap-2">
                 <button (click)="hideEditMonitor()" mat-button
-                        type="button">{{'cancel' | translate}}</button>
+                        type="button" [disabled]="savingMonitor">{{'cancel' | translate}}</button>
                 <button (click)="saveEditedMonitor()"
-                        [disabled]="!editedMonitor" color="primary" mat-raised-button
+                        [disabled]="savingMonitor || !editedMonitor" color="primary" mat-raised-button
                         matStepperNext>
                   {{'save' | translate}}
+                  <mat-spinner diameter="20" *ngIf="savingMonitor" style="margin-left:8px"></mat-spinner>
                 </button>
               </div>
             </ng-container>

--- a/src/app/pages/timeline/timeline.component.ts
+++ b/src/app/pages/timeline/timeline.component.ts
@@ -102,6 +102,8 @@ export class TimelineComponent implements OnInit, OnDestroy {
 
   showEditMonitor: boolean = false;
   editedMonitor: any;
+  saveMonitorAttempted: boolean = false;
+  savingMonitor: boolean = false;
   moveTask: boolean = false;
   moving: boolean = false;
   taskMoved: any;
@@ -1699,9 +1701,16 @@ export class TimelineComponent implements OnInit, OnDestroy {
   hideEditMonitor() {
     this.editedMonitor = null;
     this.showEditMonitor = false;
+    this.saveMonitorAttempted = false;
   }
 
   saveEditedMonitor() {
+    this.saveMonitorAttempted = true;
+    if (!this.editedMonitor) {
+      return;
+    }
+
+    this.savingMonitor = true;
     let data: any;
     let all_booking_users = [];
     let subgroup_id = [];
@@ -1739,7 +1748,7 @@ export class TimelineComponent implements OnInit, OnDestroy {
 
     this.crudService.post('/admin/planner/monitors/transfer', data)
       .subscribe((data) => {
-
+        this.savingMonitor = false;
         this.editedMonitor = null;
         this.showEditMonitor = false;
         this.hideDetail();
@@ -1747,6 +1756,7 @@ export class TimelineComponent implements OnInit, OnDestroy {
         this.snackbar.open(this.translateService.instant('snackbar.monitor.update'), 'OK', { duration: 3000 });
       },
         (error) => {
+          this.savingMonitor = false;
           // Error handling code
           console.error('Error occurred:', error);
           if (error.error && error.error.message && error.error.message == "Overlap detected. Monitor cannot be transferred.") {


### PR DESCRIPTION
## Summary
- validate edited monitor before saving
- add saving state to disable controls
- show monitor language codes when choosing monitors

## Testing
- `ng test --watch=false` *(fails: Could not find the '@angular-devkit/build-angular:karma' builder)*

------
https://chatgpt.com/codex/tasks/task_e_6882866b8be88320991b55a4ba91c1d7