### PR TITLE
Update timeline language filter

### DIFF
--- a/src/app/pages/timeline/timeline.component.html
+++ b/src/app/pages/timeline/timeline.component.html
@@ -150,14 +150,23 @@
             </mat-checkbox>
           </div>
 
-          <div class="filter-container-column">
-            <span>{{ 'language' | translate | uppercase }}</span>
-            <mat-checkbox *ngFor="let lang of languages" color="primary"
-                          [checked]="selectedLanguages.includes(lang.id)"
-                          (change)="onLanguageChange(lang.id, $event.checked)">
-              {{ lang.code.toUpperCase() }}
-            </mat-checkbox>
-          </div>
+          <mat-form-field class="filter-container-column" appearance="outline">
+            <mat-select [placeholder]="'choose_langs' | translate" multiple
+                        (selectionChange)="onLanguagesSelect($event)" [value]="selectedLanguages">
+              <mat-select-trigger>
+                <mat-chip-list #chipList>
+                  <mat-chip *ngFor="let id of selectedLanguages" [removable]="true"
+                            (removed)="removeLanguage(id)">
+                    {{ getLanguageById(id) }}
+                    <mat-icon matChipRemove>cancel</mat-icon>
+                  </mat-chip>
+                </mat-chip-list>
+              </mat-select-trigger>
+              <mat-option *ngFor="let lang of languages" [value]="lang.id">
+                {{ lang.code.toUpperCase() }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
         </div>
       </div>
 

--- a/src/app/pages/timeline/timeline.component.ts
+++ b/src/app/pages/timeline/timeline.component.ts
@@ -33,6 +33,7 @@ import {ConfirmUnmatchMonitorComponent} from './confirm-unmatch-monitor/confirm-
 import {firstValueFrom, Observable, Subject} from 'rxjs';
 import {map, startWith, takeUntil} from 'rxjs/operators';
 import {FormControl} from '@angular/forms';
+import { MatSelectChange } from '@angular/material/select';
 import {DateAdapter} from '@angular/material/core';
 import {Router} from '@angular/router';
 import {EditDateComponent} from './edit-date/edit-date.component';
@@ -2118,14 +2119,12 @@ export class TimelineComponent implements OnInit, OnDestroy {
     }
   }
 
-  onLanguageChange(langId: number, isChecked: boolean) {
-    if (isChecked) {
-      if (!this.selectedLanguages.includes(langId)) {
-        this.selectedLanguages.push(langId);
-      }
-    } else {
-      this.selectedLanguages = this.selectedLanguages.filter(id => id !== langId);
-    }
+  onLanguagesSelect(event: MatSelectChange) {
+    this.selectedLanguages = event.value;
+  }
+
+  removeLanguage(langId: number) {
+    this.selectedLanguages = this.selectedLanguages.filter(id => id !== langId);
   }
 
   areAllChecked() {

--- a/src/app/pages/timeline/timeline.module.ts
+++ b/src/app/pages/timeline/timeline.module.ts
@@ -24,6 +24,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
+import { MatChipsModule } from '@angular/material/chips';
 import { TimelineComponent } from './timeline.component';
 import { TimelineRoutingModule } from './timeline-routing.module';
 import { ComponentsCustomModule } from '../../components/components-custom.module';
@@ -77,7 +78,8 @@ import { EditDateComponent } from './edit-date/edit-date.component';
     MatDatepickerModule,
     ConfirmUnmatchMonitorModule,
     MatAutocompleteModule,
-    ScrollingModule
+    ScrollingModule,
+    MatChipsModule
   ]
 })
 export class TimelineModule {


### PR DESCRIPTION
## Summary
- enable chip-based language selection on timeline filters
- add Angular Material chips module to timeline page
- replace checkbox list with multiselect that displays language chips
- adjust component logic for chip removal

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688349805dcc832089de89c48719a710