### PR TITLE
Update README with project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,44 @@
-**Edit a file, create a new file, and clone from Bitbucket in under 2 minutes**
+# Boukii Admin Panel
 
-When you're done, you can delete the content in this README and update the file with details for others getting started with your repository.
+Boukii Admin Panel is an Angular 16 application used to manage bookings, clients and courses for Boukii. The project is built on top of the Vex theme and integrates with Boukii's REST APIs.
 
-*We recommend that you open this README in another tab as you perform the tasks below. You can [watch our video](https://youtu.be/0ocf7u76WSo) for a full demo of all the steps in this tutorial. Open the video in a new tab to avoid leaving Bitbucket.*
+## Setup
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm start
+```
+
+The app runs on `http://localhost:4200` by default.
+
+## Building
+
+Create an optimized build using Angular's production configuration:
+
+```bash
+npm run build
+# or specify a configuration
+ng build --configuration=production
+```
+
+## Running Tests
+
+Execute unit tests with Karma and Jasmine:
+
+```bash
+npm test
+```
+
+Additional commands such as `npm run lint` and `npm run e2e` are defined in `package.json`.
+
+## Booking V3 Module
+
+The repository contains the experimental **booking-v3** module under `src/app/bookings-v3`. This module provides a new booking wizard with a flexible service layer. Services can run against mock data or real API endpoints. The selection is controlled via the `useRealServices` flag in the environment configuration as documented in `src/app/bookings-v3/INTEGRATION-GUIDE.md`.
+
+For a quick demo of the mock implementation see `src/app/bookings-v3/DEMO-SETUP.md`.
 
 ---
 
-## Edit a file
-
-You’ll start by editing this README file to learn how to edit a file in Bitbucket.
-
-1. Click **Source** on the left side.
-2. Click the README.md link from the list of files.
-3. Click the **Edit** button.
-4. Delete the following text: *Delete this line to make a change to the README from Bitbucket.*
-5. After making your change, click **Commit** and then **Commit** again in the dialog. The commit page will open and you’ll see the change you just made.
-6. Go back to the **Source** page.
-
----
-
-## Create a file
-
-Next, you’ll add a new file to this repository.
-
-1. Click the **New file** button at the top of the **Source** page.
-2. Give the file a filename of **contributors.txt**.
-3. Enter your name in the empty file space.
-4. Click **Commit** and then **Commit** again in the dialog.
-5. Go back to the **Source** page.
-
-Before you move on, go ahead and explore the repository. You've already seen the **Source** page, but check out the **Commits**, **Branches**, and **Settings** pages.
-
----
-
-## Clone a repository
-
-Use these steps to clone from SourceTree, our client for using the repository command-line free. Cloning allows you to work on your files locally. If you don't yet have SourceTree, [download and install first](https://www.sourcetreeapp.com/). If you prefer to clone from the command line, see [Clone a repository](https://confluence.atlassian.com/x/4whODQ).
-
-1. You’ll see the clone button under the **Source** heading. Click that button.
-2. Now click **Check out in SourceTree**. You may need to create a SourceTree account or log in.
-3. When you see the **Clone New** dialog in SourceTree, update the destination path and name if you’d like to and then click **Clone**.
-4. Open the directory you just created to see your repository’s files.
-
-Now that you're more familiar with your Bitbucket repository, go ahead and add a new file locally. You can [push your change back to Bitbucket with SourceTree](https://confluence.atlassian.com/x/iqyBMg), or you can [add, commit,](https://confluence.atlassian.com/x/8QhODQ) and [push from the command line](https://confluence.atlassian.com/x/NQ0zDQ).
+See `CLAUDE.md` for more development commands and `booking-system-v3-api-specification.md` for API details.


### PR DESCRIPTION
## Summary
- update README with Boukii Admin Panel overview
- add setup, build and test instructions
- link Booking V3 module docs and describe mock vs real services

## Testing
- `npm test` *(fails: Cannot find module 'karma-coverage-istanbul-reporter')*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68834f7963948320824cb181bad0e070