### PR TITLE
Add Jasmine specs for SkiPro booking components

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~6.3.4",
     "karma-chrome-launcher": "~3.1.0",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "~1.7.0",
     "postcss": "~8.4.14",

--- a/src/app/bookings-v3/components/skipro-reservas-list/skipro-reservas-list.component.spec.ts
+++ b/src/app/bookings-v3/components/skipro-reservas-list/skipro-reservas-list.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+import { SkiProReservasListComponent } from './skipro-reservas-list.component';
+import { SkiProMockDataService } from '../../services/mock/skipro-mock-data.service';
+
+describe('SkiProReservasListComponent', () => {
+  let component: SkiProReservasListComponent;
+  let fixture: ComponentFixture<SkiProReservasListComponent>;
+  let serviceSpy: jasmine.SpyObj<SkiProMockDataService>;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('SkiProMockDataService', ['getReservas', 'getKPIs', 'getReservasFiltradas']);
+    serviceSpy.getReservas.and.returnValue(of([]));
+    serviceSpy.getKPIs.and.returnValue(of({ cursos: 0, actividades: 0, material: 0, confirmadas: 0, pagadas: 0, canceladas: 0 }));
+    serviceSpy.getReservasFiltradas.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [SkiProReservasListComponent],
+      providers: [{ provide: SkiProMockDataService, useValue: serviceSpy }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SkiProReservasListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should filter reservas', fakeAsync(() => {
+    const mockReserva = {
+      id: '1',
+      cliente: { nombre: 'A', apellido: 'B', email: 'a@b.com', telefono: '', iniciales: 'AB' },
+      tipo: 'Curso',
+      tipoIcon: '🎓',
+      tipoColor: '#fff',
+      reserva: { nombre: 'Curso', descripcion: '', detalles: '' },
+      fechas: { inicio: new Date(), display: '' },
+      estado: 'Confirmado',
+      estadoColor: '#fff',
+      precio: 0,
+      moneda: '€'
+    } as any;
+
+    serviceSpy.getReservasFiltradas.and.returnValue(of([mockReserva]));
+
+    component.aplicarFiltro('Cursos');
+    tick();
+
+    expect(serviceSpy.getReservasFiltradas).toHaveBeenCalledWith('Cursos');
+    expect(component.reservasFiltradas().length).toBe(1);
+  }));
+});

--- a/src/app/bookings-v3/components/skipro-wizard-inline/skipro-wizard-inline.component.spec.ts
+++ b/src/app/bookings-v3/components/skipro-wizard-inline/skipro-wizard-inline.component.spec.ts
@@ -1,0 +1,62 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { SkiProWizardInlineComponent } from './skipro-wizard-inline.component';
+import { SkiProMockDataService } from '../../services/mock/skipro-mock-data.service';
+import { MockDataService } from '../../services/mock/mock-data.service';
+
+describe('SkiProWizardInlineComponent', () => {
+  let component: SkiProWizardInlineComponent;
+  let fixture: ComponentFixture<SkiProWizardInlineComponent>;
+  let skiproSpy: jasmine.SpyObj<SkiProMockDataService>;
+  let mockSpy: jasmine.SpyObj<MockDataService>;
+
+  beforeEach(async () => {
+    skiproSpy = jasmine.createSpyObj('SkiProMockDataService', ['getClientesParaWizard', 'getTiposReserva', 'getCursos', 'crearReserva']);
+    mockSpy = jasmine.createSpyObj('MockDataService', ['getOptimalSlots', 'getMockWeatherInfo', 'getAvailableCourses', 'calculateDynamicPricing']);
+
+    skiproSpy.getClientesParaWizard.and.returnValue(of([]));
+    skiproSpy.getTiposReserva.and.returnValue(of([]));
+    skiproSpy.getCursos.and.returnValue(of([]));
+    skiproSpy.crearReserva.and.returnValue(of({ success: true, reserva: { id: 'RES' } } as any));
+
+    mockSpy.getOptimalSlots.and.returnValue(of([]));
+    mockSpy.getMockWeatherInfo.and.returnValue({} as any);
+    mockSpy.getAvailableCourses.and.returnValue(of([]));
+    mockSpy.calculateDynamicPricing.and.returnValue(of({ finalPrice: 0 }));
+
+    await TestBed.configureTestingModule({
+      declarations: [SkiProWizardInlineComponent],
+      providers: [
+        { provide: SkiProMockDataService, useValue: skiproSpy },
+        { provide: MockDataService, useValue: mockSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SkiProWizardInlineComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit close event', () => {
+    spyOn(component.cerrar, 'emit');
+    component.cerrarWizard();
+    expect(component.cerrar.emit).toHaveBeenCalled();
+  });
+
+  it('should emit reservaCreada on confirm', async () => {
+    spyOn(component.reservaCreada, 'emit');
+    component.wizardState.set({
+      paso: 4,
+      cliente: { id: 1, nombre: 'A', apellido: 'B', iniciales: 'AB', email: 'a', telefono: '', nivel: 'Intermedio', fechaRegistro: new Date(), totalReservas: 0, cursosCompletados: 0, gastoTotal: 0, reservasActivas: [], historial: [], preferencias: [] },
+      tipoReserva: { id: 't', nombre: 'T', descripcion: '', icon: '', color: '' },
+      cursoSeleccionado: { id: 1, nombre: 'C', descripcion: '', duracion: '', nivel: 'Intermedio', precio: 0, detalles: [] }
+    } as any);
+    await component.confirmarReserva();
+    expect(component.reservaCreada.emit).toHaveBeenCalled();
+  });
+});

--- a/src/app/bookings-v3/components/skipro-wizard/skipro-wizard.component.spec.ts
+++ b/src/app/bookings-v3/components/skipro-wizard/skipro-wizard.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+import { SkiProWizardComponent } from './skipro-wizard.component';
+import { SkiProMockDataService } from '../../services/mock/skipro-mock-data.service';
+
+describe('SkiProWizardComponent', () => {
+  let component: SkiProWizardComponent;
+  let fixture: ComponentFixture<SkiProWizardComponent>;
+  let serviceSpy: jasmine.SpyObj<SkiProMockDataService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('SkiProMockDataService', ['getClientesParaWizard', 'getTiposReserva', 'getCursos']);
+    serviceSpy.getClientesParaWizard.and.returnValue(of([]));
+    serviceSpy.getTiposReserva.and.returnValue(of([]));
+    serviceSpy.getCursos.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [SkiProWizardComponent],
+      providers: [{ provide: SkiProMockDataService, useValue: serviceSpy }]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(SkiProWizardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should advance to next step', () => {
+    component.wizardState.set({ paso: 1, cliente: {} as any });
+    component.pasoSiguiente();
+    expect(component.wizardState().paso).toBe(2);
+  });
+
+  it('should navigate on close', () => {
+    spyOn(router, 'navigate');
+    component.cerrarWizard();
+    expect(router.navigate).toHaveBeenCalledWith(['/bookings-v3/skipro']);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `skipro-reservas-list`, `skipro-wizard` and `skipro-wizard-inline`
- include Karma coverage reporter needed for running tests

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68834f4ab9848320bcc9917be4ca3a6a