### PR TITLE
Sync scroll in timeline viewports

### DIFF
--- a/src/app/pages/timeline/timeline.component.html
+++ b/src/app/pages/timeline/timeline.component.html
@@ -175,7 +175,7 @@
         <div class="schedule-container"
              *ngIf="filteredMonitors && filteredMonitors.length && timelineView != 'month'">
           <div class="monitors-column">
-            <cdk-virtual-scroll-viewport itemSize="100" class="monitors-viewport">
+            <cdk-virtual-scroll-viewport #monitorsViewport itemSize="100" class="monitors-viewport">
               <ng-container *cdkVirtualFor="let monitor of filteredMonitors">
                 <div class="monitor">
                   <ng-container *ngIf="monitor.id">
@@ -289,7 +289,7 @@
               </div>
 
               <!--TASKS-->
-              <cdk-virtual-scroll-viewport itemSize="100" class="tasks-viewport" (scrolledIndexChange)="onTasksScroll($event)">
+              <cdk-virtual-scroll-viewport #tasksViewport itemSize="100" class="tasks-viewport" (scrolledIndexChange)="onTasksScroll($event)" (elementScrolled)="onTasksScrolled()">
                 <ng-container *cdkVirtualFor="let task of plannerTasks">
                   <!--DAY-->
                   <div *ngIf="timelineView == 'day'"

--- a/src/app/pages/timeline/timeline.component.ts
+++ b/src/app/pages/timeline/timeline.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {
   addDays,
   addMonths,
@@ -38,6 +38,7 @@ import {DateAdapter} from '@angular/material/core';
 import {Router} from '@angular/router';
 import {EditDateComponent} from './edit-date/edit-date.component';
 import {BookingDetailV2Component} from '../bookings-v2/booking-detail/booking-detail.component';
+import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 
 moment.locale('fr');
 
@@ -77,6 +78,8 @@ export class TimelineComponent implements OnInit, OnDestroy {
   pageSize: number = 50;
   moreData: boolean = true;
   loadingMore: boolean = false;
+  @ViewChild('monitorsViewport') monitorsViewport!: CdkVirtualScrollViewport;
+  @ViewChild('tasksViewport') tasksViewport!: CdkVirtualScrollViewport;
   vacationDays: any[];
 
   user: any = null;
@@ -460,6 +463,11 @@ export class TimelineComponent implements OnInit, OnDestroy {
       }
       this.searchBookings(firstDate, lastDate, this.page);
     }
+  }
+
+  onTasksScrolled(): void {
+    const offset = this.tasksViewport.measureScrollOffset();
+    this.monitorsViewport.scrollToOffset(offset);
   }
 
   normalizeToArray(data: any) {


### PR DESCRIPTION
## Summary
- reference monitors and tasks virtual scroll viewports in the timeline template
- sync the monitors viewport when the tasks viewport scrolls

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883554415008320b887a6604d47f9f0