### PR TITLE
Fix scroll sync in timeline

### DIFF
--- a/src/app/pages/timeline/timeline.component.html
+++ b/src/app/pages/timeline/timeline.component.html
@@ -175,7 +175,7 @@
         <div class="schedule-container"
              *ngIf="filteredMonitors && filteredMonitors.length && timelineView != 'month'">
           <div class="monitors-column">
-            <cdk-virtual-scroll-viewport #monitorsViewport itemSize="100" class="monitors-viewport">
+            <cdk-virtual-scroll-viewport #monitorsViewport itemSize="100" class="monitors-viewport" (elementScrolled)="onMonitorsScrolled()" (wheel)="onMonitorsWheel($event)">
               <ng-container *cdkVirtualFor="let monitor of filteredMonitors">
                 <div class="monitor">
                   <ng-container *ngIf="monitor.id">
@@ -430,7 +430,7 @@
         <div class="schedule-container"
              *ngIf="filteredMonitors && filteredMonitors.length && timelineView == 'month'">
           <div class="monitors-column">
-            <cdk-virtual-scroll-viewport itemSize="100" class="monitors-viewport">
+            <cdk-virtual-scroll-viewport #monitorsViewport itemSize="100" class="monitors-viewport" (elementScrolled)="onMonitorsScrolled()" (wheel)="onMonitorsWheel($event)">
               <ng-container
                 *cdkVirtualFor="let monitor of filteredMonitors; let monitorIndex = index">
                 <ng-container
@@ -547,7 +547,7 @@
               </ng-container>
 
               <!--TASKS-->
-              <cdk-virtual-scroll-viewport itemSize="100" class="tasks-viewport" (scrolledIndexChange)="onTasksScroll($event)">
+              <cdk-virtual-scroll-viewport #tasksViewport itemSize="100" class="tasks-viewport" (scrolledIndexChange)="onTasksScroll($event)" (elementScrolled)="onTasksScrolled()">
                 <ng-container *cdkVirtualFor="let task of plannerTasks">
                   <!--MONTH-->
                   <div class="task-wrapper-week cursor-pointer"

--- a/src/app/pages/timeline/timeline.component.scss
+++ b/src/app/pages/timeline/timeline.component.scss
@@ -242,6 +242,7 @@
 .monitors-viewport {
   height: calc(100vh - 200px);
   width: 100%;
+  overflow: hidden;
 }
 
 .tasks-viewport {

--- a/src/app/pages/timeline/timeline.component.ts
+++ b/src/app/pages/timeline/timeline.component.ts
@@ -470,6 +470,17 @@ export class TimelineComponent implements OnInit, OnDestroy {
     this.monitorsViewport.scrollToOffset(offset);
   }
 
+  onMonitorsScrolled(): void {
+    const offset = this.monitorsViewport.measureScrollOffset();
+    this.tasksViewport.scrollToOffset(offset);
+  }
+
+  onMonitorsWheel(event: WheelEvent): void {
+    event.preventDefault();
+    const offset = this.tasksViewport.measureScrollOffset();
+    this.tasksViewport.scrollToOffset(offset + event.deltaY);
+  }
+
   normalizeToArray(data: any) {
     //Nwds sometimes as object sometimes as array
     if (Array.isArray(data)) {


### PR DESCRIPTION
## Summary
- sync scroll between monitors and tasks
- hide overflow for monitors list
- add wheel handler for monitors column

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835f0b230c8320a808fa13ff0ec305