### PR TITLE
Remove virtual scrolling from timeline

### DIFF
--- a/src/app/pages/timeline/timeline.component.html
+++ b/src/app/pages/timeline/timeline.component.html
@@ -172,14 +172,13 @@
 
       <div class="header-navigation2">
 
-        <div class="schedule-container"
+          <div class="schedule-container"
              *ngIf="filteredMonitors && filteredMonitors.length && timelineView != 'month'">
           <div class="monitors-column">
-            <cdk-virtual-scroll-viewport #monitorsViewport itemSize="100" class="monitors-viewport" (elementScrolled)="onMonitorsScrolled()" (wheel)="onMonitorsWheel($event)">
-              <ng-container *cdkVirtualFor="let monitor of filteredMonitors">
-                <div class="monitor">
-                  <ng-container *ngIf="monitor.id">
-                    <div class="monitor-left">
+            <ng-container *ngFor="let monitor of filteredMonitors">
+              <div class="monitor">
+                <ng-container *ngIf="monitor.id">
+                  <div class="monitor-left">
 
                       <ng-container
                         *ngFor="let sport of monitor.sports; let i = index">
@@ -247,8 +246,9 @@
                     </div>
                   </ng-container>
                 </div>
-              </ng-container>
-            </cdk-virtual-scroll-viewport>
+                </ng-container>
+              </div>
+            </ng-container>
           </div>
           <div class="hours-container">
             <div class="hours-row" *ngIf="timelineView == 'day'">
@@ -289,13 +289,12 @@
               </div>
 
               <!--TASKS-->
-              <cdk-virtual-scroll-viewport #tasksViewport itemSize="100" class="tasks-viewport" (scrolledIndexChange)="onTasksScroll($event)" (elementScrolled)="onTasksScrolled()">
-                <ng-container *cdkVirtualFor="let task of plannerTasks">
-                  <!--DAY-->
-                  <div *ngIf="timelineView == 'day'"
-                       (click)="task.block_id ? toggleBlock(task) : toggleDetail(task)"
-                       (contextmenu)="task.grouped_tasks && task.grouped_tasks.length > 1 ?
-                     $event.preventDefault() : toggleDetailMove(task, $event)"
+              <ng-container *ngFor="let task of plannerTasks">
+                <!--DAY-->
+                <div *ngIf="timelineView == 'day'"
+                     (click)="task.block_id ? toggleBlock(task) : toggleDetail(task)"
+                     (contextmenu)="task.grouped_tasks && task.grouped_tasks.length > 1 ?
+                   $event.preventDefault() : toggleDetailMove(task, $event)"
                        class="task-wrapper cursor-pointer" [ngClass]="[
                                 (task.booking_id && ((idDetail == task.booking_id &&
                                 hourDetail == task.hour_start && dateDetail == task.date
@@ -421,22 +420,21 @@
                     </ng-container>
                   </div>
                 </ng-container>
-              </cdk-virtual-scroll-viewport>
+              </ng-container>
 
             </div>
           </div>
         </div>
 
-        <div class="schedule-container"
+          <div class="schedule-container"
              *ngIf="filteredMonitors && filteredMonitors.length && timelineView == 'month'">
           <div class="monitors-column">
-            <cdk-virtual-scroll-viewport #monitorsViewport itemSize="100" class="monitors-viewport" (elementScrolled)="onMonitorsScrolled()" (wheel)="onMonitorsWheel($event)">
+            <ng-container
+              *ngFor="let monitor of filteredMonitors; let monitorIndex = index">
               <ng-container
-                *cdkVirtualFor="let monitor of filteredMonitors; let monitorIndex = index">
-                <ng-container
-                  *ngFor="let week of weeksInMonth; let weekIndex = index">
-                  <div class="monitor"
-                       [ngClass]="{'big-border': weekIndex === 0 && monitorIndex !== 0}">
+                *ngFor="let week of weeksInMonth; let weekIndex = index">
+                <div class="monitor"
+                     [ngClass]="{'big-border': weekIndex === 0 && monitorIndex !== 0}">
                     <ng-container *ngIf="weekIndex === 0">
                       <ng-container *ngIf="monitor.id">
                         <div class="monitor-left">
@@ -512,7 +510,7 @@
                   </div>
                 </ng-container>
               </ng-container>
-            </cdk-virtual-scroll-viewport>
+            </ng-container>
           </div>
           <div class="hours-container">
             <div class="hours-row">
@@ -546,9 +544,8 @@
                 </div>
               </ng-container>
 
-              <!--TASKS-->
-              <cdk-virtual-scroll-viewport #tasksViewport itemSize="100" class="tasks-viewport" (scrolledIndexChange)="onTasksScroll($event)" (elementScrolled)="onTasksScrolled()">
-                <ng-container *cdkVirtualFor="let task of plannerTasks">
+                <!--TASKS-->
+                <ng-container *ngFor="let task of plannerTasks">
                   <!--MONTH-->
                   <div class="task-wrapper-week cursor-pointer"
                        (click)="task.block_id ? toggleBlock(task) : toggleDetail(task)"
@@ -600,8 +597,8 @@
                       </div>
                     </ng-container>
                   </div>
+                  </ng-container>
                 </ng-container>
-              </cdk-virtual-scroll-viewport>
 
             </div>
           </div>

--- a/src/app/pages/timeline/timeline.component.scss
+++ b/src/app/pages/timeline/timeline.component.scss
@@ -68,6 +68,8 @@
 
 .schedule-container {
   display: flex;
+  height: calc(100vh - 200px);
+  overflow-y: auto;
 }
 .monitors-column {
   flex-shrink: 0;
@@ -239,17 +241,6 @@
   border-bottom: none;
 }
 
-.monitors-viewport {
-  height: calc(100vh - 200px);
-  width: 100%;
-  overflow: hidden;
-}
-
-.tasks-viewport {
-  height: calc(100vh - 200px);
-  width: 100%;
-  overflow: auto;
-}
 .grid-cell:last-child {
   border-right: none;
 }

--- a/src/app/pages/timeline/timeline.component.ts
+++ b/src/app/pages/timeline/timeline.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {
   addDays,
   addMonths,
@@ -38,7 +38,6 @@ import {DateAdapter} from '@angular/material/core';
 import {Router} from '@angular/router';
 import {EditDateComponent} from './edit-date/edit-date.component';
 import {BookingDetailV2Component} from '../bookings-v2/booking-detail/booking-detail.component';
-import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 
 moment.locale('fr');
 
@@ -78,8 +77,6 @@ export class TimelineComponent implements OnInit, OnDestroy {
   pageSize: number = 50;
   moreData: boolean = true;
   loadingMore: boolean = false;
-  @ViewChild('monitorsViewport') monitorsViewport!: CdkVirtualScrollViewport;
-  @ViewChild('tasksViewport') tasksViewport!: CdkVirtualScrollViewport;
   vacationDays: any[];
 
   user: any = null;
@@ -419,8 +416,8 @@ export class TimelineComponent implements OnInit, OnDestroy {
 
   }
 
-  searchBookings(firstDate: string, lastDate: string, page: number = 1) {
-    let params = '/admin/getPlanner?date_start=' + firstDate + '&date_end=' + lastDate + '&school_id=' + this.activeSchool + '&perPage=' + this.pageSize + '&page=' + page;
+  searchBookings(firstDate: string, lastDate: string) {
+    let params = '/admin/getPlanner?date_start=' + firstDate + '&date_end=' + lastDate + '&school_id=' + this.activeSchool + '&perPage=99999';
     if (this.selectedLanguages.length) {
       this.selectedLanguages.forEach(id => {
         params += `&languages[]=${id}`;
@@ -428,58 +425,13 @@ export class TimelineComponent implements OnInit, OnDestroy {
     }
     this.crudService.get(params).subscribe(
       (data: any) => {
-        if (page === 1) {
-          this.processData(data.data);
-        } else {
-          this.processData(data.data, true);
-        }
-        this.moreData = data.data && data.data.length === this.pageSize;
-        this.loadingMore = false;
+        this.processData(data.data);
       },
       error => {
-        this.loadingMore = false;
       }
     );
   }
 
-  onTasksScroll(index: number) {
-    if (this.moreData && !this.loadingMore && index + 10 >= this.plannerTasks.length) {
-      this.loadingMore = true;
-      this.page++;
-      let firstDate, lastDate;
-      if (this.timelineView === 'week') {
-        const startOfWeekDate = startOfWeek(this.currentDate, { weekStartsOn: 1 });
-        const endOfWeekDate = endOfWeek(this.currentDate, { weekStartsOn: 1 });
-        firstDate = moment(startOfWeekDate).format('YYYY-MM-DD');
-        lastDate = moment(endOfWeekDate).format('YYYY-MM-DD');
-      } else if (this.timelineView === 'month') {
-        const startMonth = startOfMonth(this.currentDate);
-        const endMonth = endOfMonth(this.currentDate);
-        firstDate = moment(startMonth).format('YYYY-MM-DD');
-        lastDate = moment(endMonth).format('YYYY-MM-DD');
-      } else {
-        firstDate = moment(this.currentDate).format('YYYY-MM-DD');
-        lastDate = firstDate;
-      }
-      this.searchBookings(firstDate, lastDate, this.page);
-    }
-  }
-
-  onTasksScrolled(): void {
-    const offset = this.tasksViewport.measureScrollOffset();
-    this.monitorsViewport.scrollToOffset(offset);
-  }
-
-  onMonitorsScrolled(): void {
-    const offset = this.monitorsViewport.measureScrollOffset();
-    this.tasksViewport.scrollToOffset(offset);
-  }
-
-  onMonitorsWheel(event: WheelEvent): void {
-    event.preventDefault();
-    const offset = this.tasksViewport.measureScrollOffset();
-    this.tasksViewport.scrollToOffset(offset + event.deltaY);
-  }
 
   normalizeToArray(data: any) {
     //Nwds sometimes as object sometimes as array

--- a/src/app/pages/timeline/timeline.module.ts
+++ b/src/app/pages/timeline/timeline.module.ts
@@ -35,7 +35,6 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { TranslateModule } from '@ngx-translate/core';
 import { ConfirmUnmatchMonitorModule } from './confirm-unmatch-monitor/confirm-unmatch-monitor.module';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { ScrollingModule } from '@angular/cdk/scrolling';
 import { IconComponent } from 'src/@vex/components/icon/app.component';
 import { EditDateComponent } from './edit-date/edit-date.component';
 import {MatLegacyChipsModule} from '@angular/material/legacy-chips';
@@ -79,7 +78,6 @@ import {MatLegacyChipsModule} from '@angular/material/legacy-chips';
     MatDatepickerModule,
     ConfirmUnmatchMonitorModule,
     MatAutocompleteModule,
-    ScrollingModule,
     MatChipsModule,
     MatLegacyChipsModule
   ]


### PR DESCRIPTION
## Summary
- ditch virtual scroll containers in timeline templates
- remove scrolling helpers from TimelineComponent
- keep schedule scrolling via single container
- drop ScrollingModule dependency

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883651a7e208320b571226b1027b8a7