### PR TITLE
Add feature flags and service factory cleanup

### DIFF
--- a/src/app/bookings-v3/services/service.factory.ts
+++ b/src/app/bookings-v3/services/service.factory.ts
@@ -1,6 +1,8 @@
 import { inject, InjectionToken } from '@angular/core';
 import { environment } from '../../../environments/environment';
 
+const useReal = environment.useRealServices;
+
 import { SmartBookingService } from './smart-booking.service';
 import { SmartClientService } from './smart-client.service';
 import { ClientAnalyticsService } from './client-analytics.service';
@@ -26,45 +28,45 @@ export const PARTICIPANT_DETAILS_SERVICE = new InjectionToken<ParticipantDetails
 export const PRICING_CONFIRMATION_SERVICE = new InjectionToken<PricingConfirmationService>('PricingConfirmationService');
 
 export function smartBookingServiceFactory() {
-  return environment.useRealServices ?
-    inject(SmartBookingService) :
-    inject(SmartBookingServiceMock);
+  return useReal
+    ? inject(SmartBookingService)
+    : inject(SmartBookingServiceMock);
 }
 
 export function smartClientServiceFactory() {
-  return environment.useRealServices ?
-    inject(SmartClientService) :
-    inject(SmartClientServiceMock);
+  return useReal
+    ? inject(SmartClientService)
+    : inject(SmartClientServiceMock);
 }
 
 export function clientAnalyticsServiceFactory() {
-  return environment.useRealServices ?
-    inject(ClientAnalyticsService) :
-    inject(ClientAnalyticsServiceMock);
+  return useReal
+    ? inject(ClientAnalyticsService)
+    : inject(ClientAnalyticsServiceMock);
 }
 
 export function activitySelectionServiceFactory() {
-  return environment.useRealServices ?
-    inject(ActivitySelectionService) :
-    inject(ActivitySelectionServiceMock);
+  return useReal
+    ? inject(ActivitySelectionService)
+    : inject(ActivitySelectionServiceMock);
 }
 
 export function scheduleSelectionServiceFactory() {
-  return environment.useRealServices ?
-    inject(ScheduleSelectionService) :
-    inject(ScheduleSelectionServiceMock);
+  return useReal
+    ? inject(ScheduleSelectionService)
+    : inject(ScheduleSelectionServiceMock);
 }
 
 export function participantDetailsServiceFactory() {
-  return environment.useRealServices ?
-    inject(ParticipantDetailsService) :
-    inject(ParticipantDetailsServiceMock);
+  return useReal
+    ? inject(ParticipantDetailsService)
+    : inject(ParticipantDetailsServiceMock);
 }
 
 export function pricingConfirmationServiceFactory() {
-  return environment.useRealServices ?
-    inject(PricingConfirmationService) :
-    inject(PricingConfirmationServiceMock);
+  return useReal
+    ? inject(PricingConfirmationService)
+    : inject(PricingConfirmationServiceMock);
 }
 
 export const BOOKING_V3_PROVIDERS = [

--- a/src/app/core/services/feature-flag.service.ts
+++ b/src/app/core/services/feature-flag.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FeatureFlagService {
+  get intelligentBooking(): boolean {
+    return environment.features.intelligentBooking;
+  }
+
+  get realTimePricing(): boolean {
+    return environment.features.realTimePricing;
+  }
+
+  get conflictDetection(): boolean {
+    return environment.features.conflictDetection;
+  }
+
+  get aiRecommendations(): boolean {
+    return environment.features.aiRecommendations;
+  }
+}

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -11,5 +11,11 @@ export const environment = {
     storageBucket: "boukii-test.appspot.com",
     messagingSenderId: "80492512236",
     appId: "1:80492512236:web:bba5002b4c9ec6c2e776c9"
+  },
+  features: {
+    intelligentBooking: true,
+    realTimePricing: true,
+    conflictDetection: true,
+    aiRecommendations: true
   }
 };

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -11,5 +11,11 @@ export const environment = {
     storageBucket: "boukii-test.appspot.com",
     messagingSenderId: "80492512236",
     appId: "1:80492512236:web:bba5002b4c9ec6c2e776c9"
+  },
+  features: {
+    intelligentBooking: true,
+    realTimePricing: true,
+    conflictDetection: true,
+    aiRecommendations: true
   }
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -11,5 +11,11 @@ export const environment = {
     storageBucket: "boukii-test.appspot.com",
     messagingSenderId: "80492512236",
     appId: "1:80492512236:web:bba5002b4c9ec6c2e776c9"
+  },
+  features: {
+    intelligentBooking: true,
+    realTimePricing: true,
+    conflictDetection: true,
+    aiRecommendations: true
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -15,6 +15,12 @@ export const environment = {
     storageBucket: "boukii-test.appspot.com",
     messagingSenderId: "80492512236",
     appId: "1:80492512236:web:bba5002b4c9ec6c2e776c9"
+  },
+  features: {
+    intelligentBooking: true,
+    realTimePricing: true,
+    conflictDetection: true,
+    aiRecommendations: true
   }
 };
 


### PR DESCRIPTION
## Summary
- add feature flags to all environment files
- implement `FeatureFlagService` with getters
- refactor bookings V3 service factory to use flag constant

## Testing
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm test -- --watch=false` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688369bb53b08320a6b15a67e9c3a92d