### PR TITLE
Fix timeline layout

### DIFF
--- a/src/app/pages/timeline/timeline.component.scss
+++ b/src/app/pages/timeline/timeline.component.scss
@@ -67,7 +67,8 @@
 }
 
 .schedule-container {
-  display: flex;
+  display: grid;
+  grid-template-columns: 270px 1fr;
   height: calc(100vh - 200px);
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- align monitor and task columns using CSS grid

## Testing
- `node --max-old-space-size=4096 ./node_modules/@angular/cli/bin/ng test --watch=false` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68836a1d5ecc8320abcf68e7ce26233a