### PR TITLE
Implement real booking v3 services

### DIFF
--- a/src/app/bookings-v3/services/activity-selection.service.ts
+++ b/src/app/bookings-v3/services/activity-selection.service.ts
@@ -1,6 +1,90 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+import { Course, Sport, ActivityBundle } from '../interfaces/shared.interfaces';
 
 @Injectable({ providedIn: 'root' })
 export class ActivitySelectionService {
-  // TODO: implement real activity selection logic
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.baseUrl}/v3`;
+
+  /** Obtener cursos recomendados */
+  getRecommendedCourses(criteria: {
+    clientId?: number;
+    participantCount: number;
+    level?: string;
+    sportId?: number;
+  }): Observable<Course[]> {
+    return this.http
+      .post<any>(`${this.baseUrl}/courses/recommended`, criteria)
+      .pipe(
+        map((res) => res.data?.courses || res.data || []),
+        catchError(this.handleError)
+      );
+  }
+
+  /** Obtener todos los deportes disponibles */
+  getAvailableSports(): Observable<Sport[]> {
+    return this.http.get<any>(`${this.baseUrl}/sports`).pipe(
+      map((res) => res.data?.sports || res.data || []),
+      catchError(this.handleError)
+    );
+  }
+
+  /** Obtener cursos por deporte */
+  getCoursesBySport(
+    sportId: number,
+    filters?: { level?: string; type?: string; maxParticipants?: number }
+  ): Observable<Course[]> {
+    const params: any = { ...filters };
+    return this.http
+      .get<any>(`${this.baseUrl}/sports/${sportId}/courses`, { params })
+      .pipe(
+        map((res) => res.data?.courses || res.data || []),
+        catchError(this.handleError)
+      );
+  }
+
+  /** Obtener paquetes de actividades */
+  getActivityBundles(participantCount: number): Observable<ActivityBundle[]> {
+    const params = { participantCount: participantCount.toString() } as any;
+    return this.http
+      .get<any>(`${this.baseUrl}/activities/bundles`, { params })
+      .pipe(
+        map((res) => res.data?.bundles || res.data || []),
+        catchError(this.handleError)
+      );
+  }
+
+  /** Comparar cursos seleccionados */
+  compareCourses(courseIds: number[]): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/courses/compare`, { courseIds })
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Obtener detalles extendidos de un curso */
+  getCourseDetails(courseId: number): Observable<any> {
+    return this.http
+      .get<any>(`${this.baseUrl}/courses/${courseId}`)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Verificar disponibilidad rápida */
+  quickAvailabilityCheck(courseId: number, dates: string[]): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/availability/quick-check`, {
+        courseId,
+        dates,
+      })
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  private handleError(error: any) {
+    console.error('ActivitySelectionService Error:', error);
+    return throwError(() => error);
+  }
 }

--- a/src/app/bookings-v3/services/client-analytics.service.ts
+++ b/src/app/bookings-v3/services/client-analytics.service.ts
@@ -1,6 +1,52 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class ClientAnalyticsService {
-  // TODO: implement real analytics integration
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.baseUrl}/v3/clients`;
+
+  /** Obtener insights completos */
+  getClientInsights(clientId: number): Observable<any> {
+    return this.http
+      .get<any>(`${this.baseUrl}/${clientId}/insights`)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Obtener métricas del cliente */
+  getClientMetrics(clientId: number): Observable<any> {
+    return this.http
+      .get<any>(`${this.baseUrl}/${clientId}/metrics`)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Historial de reservas */
+  getBookingHistory(clientId: number, limit: number = 10): Observable<any[]> {
+    const params = { limit: limit.toString() } as any;
+    return this.http
+      .get<any>(`${this.baseUrl}/${clientId}/bookings`, { params })
+      .pipe(map((res) => res.data?.history || res.data || []), catchError(this.handleError));
+  }
+
+  /** Preferencias del cliente */
+  getClientPreferences(clientId: number): Observable<any> {
+    return this.http
+      .get<any>(`${this.baseUrl}/${clientId}/preferences`)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Perfil de riesgo */
+  getClientRiskProfile(clientId: number): Observable<any> {
+    return this.http
+      .get<any>(`${this.baseUrl}/${clientId}/risk-profile`)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  private handleError(error: any) {
+    console.error('ClientAnalyticsService Error:', error);
+    return throwError(() => error);
+  }
 }

--- a/src/app/bookings-v3/services/participant-details.service.ts
+++ b/src/app/bookings-v3/services/participant-details.service.ts
@@ -1,6 +1,74 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+import { Participant, ParticipantValidation, EmergencyContact } from '../interfaces/shared.interfaces';
 
 @Injectable({ providedIn: 'root' })
 export class ParticipantDetailsService {
-  // TODO: implement participant validation logic
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.baseUrl}/v3/participants`;
+
+  /** Validar datos de participante */
+  validateParticipant(participant: Partial<Participant>): Observable<ParticipantValidation> {
+    return this.http
+      .post<any>(`${this.baseUrl}/validate`, participant)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Obtener niveles de habilidad */
+  getSkillLevels(sportId?: number): Observable<any[]> {
+    const params: any = {};
+    if (sportId) params.sportId = sportId.toString();
+    return this.http
+      .get<any>(`${this.baseUrl}/skill-levels`, { params })
+      .pipe(map((res) => res.data?.levels || res.data || []), catchError(this.handleError));
+  }
+
+  /** Sugerir nivel basado en experiencia */
+  suggestSkillLevel(experience: {
+    yearsExperience: number;
+    daysPerYear: number;
+    terrainComfort: string[];
+    previousLessons: boolean;
+  }): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/suggest-skill`, experience)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Validar contacto de emergencia */
+  validateEmergencyContact(contact: Partial<EmergencyContact>): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/validate-emergency`, contact)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Obtener equipamiento recomendado */
+  getRecommendedEquipment(participant: Partial<Participant>): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/recommended-equipment`, participant)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Guardar participante temporalmente */
+  saveParticipantDraft(participant: Partial<Participant>, sessionId: string): Observable<boolean> {
+    return this.http
+      .post<any>(`${this.baseUrl}/drafts`, { participant, sessionId })
+      .pipe(map((res) => !!res.success), catchError(this.handleError));
+  }
+
+  /** Obtener restricciones médicas */
+  getMedicalRestrictions(): Observable<any[]> {
+    return this.http
+      .get<any>(`${this.baseUrl}/medical-restrictions`)
+      .pipe(map((res) => res.data?.restrictions || res.data || []), catchError(this.handleError));
+  }
+
+  private handleError(error: any) {
+    console.error('ParticipantDetailsService Error:', error);
+    return throwError(() => error);
+  }
 }

--- a/src/app/bookings-v3/services/pricing-confirmation.service.ts
+++ b/src/app/bookings-v3/services/pricing-confirmation.service.ts
@@ -1,6 +1,70 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+import { PriceBreakdown, PaymentPlan, PromoCode } from '../interfaces/shared.interfaces';
 
 @Injectable({ providedIn: 'root' })
 export class PricingConfirmationService {
-  // TODO: implement real pricing logic
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.baseUrl}/v3`;
+
+  /** Calcular precio final */
+  calculateFinalPricing(bookingData: any): Observable<PriceBreakdown> {
+    return this.http
+      .post<any>(`${this.baseUrl}/pricing/calculate-dynamic`, bookingData)
+      .pipe(map((res) => res.data?.breakdown || res.data), catchError(this.handleError));
+  }
+
+  /** Validar código promocional */
+  validatePromoCode(code: string, bookingData: any): Observable<PromoCode> {
+    return this.http
+      .post<any>(`${this.baseUrl}/pricing/validate-promo`, { code, bookingData })
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Obtener planes de pago */
+  getPaymentPlans(totalAmount: number): Observable<PaymentPlan[]> {
+    const params = { amount: totalAmount.toString() } as any;
+    return this.http
+      .get<any>(`${this.baseUrl}/pricing/payment-plans`, { params })
+      .pipe(map((res) => res.data?.plans || res.data || []), catchError(this.handleError));
+  }
+
+  /** Procesar pago */
+  processPayment(paymentData: any): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/payments/process`, paymentData)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Obtener métodos de pago */
+  getPaymentMethods(clientId?: number): Observable<any[]> {
+    const params: any = {};
+    if (clientId) params.clientId = clientId.toString();
+    return this.http
+      .get<any>(`${this.baseUrl}/payments/methods`, { params })
+      .pipe(map((res) => res.data?.methods || res.data || []), catchError(this.handleError));
+  }
+
+  /** Aplicar descuentos automáticos */
+  applyAutoDiscounts(bookingData: any): Observable<any[]> {
+    return this.http
+      .post<any>(`${this.baseUrl}/pricing/auto-discounts`, bookingData)
+      .pipe(map((res) => res.data?.discounts || res.data || []), catchError(this.handleError));
+  }
+
+  /** Generar factura proforma */
+  generateProformaInvoice(bookingData: any): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/pricing/proforma-invoice`, bookingData)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  private handleError(error: any) {
+    console.error('PricingConfirmationService Error:', error);
+    return throwError(() => error);
+  }
 }

--- a/src/app/bookings-v3/services/schedule-selection.service.ts
+++ b/src/app/bookings-v3/services/schedule-selection.service.ts
@@ -1,6 +1,91 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+import { TimeSlot, ScheduleOption, CalendarDay } from '../interfaces/shared.interfaces';
 
 @Injectable({ providedIn: 'root' })
 export class ScheduleSelectionService {
-  // TODO: implement real schedule selection logic
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.baseUrl}/v3`;
+
+  /** Obtener calendario de disponibilidad */
+  getAvailabilityCalendar(courseId: number, month?: Date): Observable<CalendarDay[]> {
+    const params: any = { courseId: courseId.toString() };
+    if (month) params.month = month.toISOString().split('T')[0];
+    return this.http
+      .get<any>(`${this.baseUrl}/availability/calendar`, { params })
+      .pipe(map((res) => res.data?.days || res.data || []), catchError(this.handleError));
+  }
+
+  /** Obtener horarios disponibles para una fecha */
+  getAvailableTimeSlots(courseId: number, date: string): Observable<TimeSlot[]> {
+    const params: any = { courseId: courseId.toString(), date };
+    return this.http
+      .get<any>(`${this.baseUrl}/availability/time-slots`, { params })
+      .pipe(map((res) => res.data?.slots || res.data || []), catchError(this.handleError));
+  }
+
+  /** Obtener opciones de horario recomendadas */
+  getRecommendedSchedules(criteria: {
+    courseId: number;
+    participantCount: number;
+    preferredDates?: string[];
+    timePreferences?: string[];
+    budgetRange?: { min: number; max: number };
+  }): Observable<ScheduleOption[]> {
+    return this.http
+      .post<any>(`${this.baseUrl}/availability/optimal-slots`, criteria)
+      .pipe(map((res) => res.data?.optimalSlots || res.data || []), catchError(this.handleError));
+  }
+
+  /** Verificar disponibilidad específica */
+  checkSpecificAvailability(courseId: number, dates: string[], timeSlotIds: number[]): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/availability/realtime-check`, {
+        courseId,
+        dates,
+        timeSlots: timeSlotIds,
+      })
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Obtener información de precios por fecha */
+  getPricingByDates(courseId: number, startDate: string, endDate: string): Observable<any> {
+    const params: any = { courseId: courseId.toString(), startDate, endDate };
+    return this.http
+      .get<any>(`${this.baseUrl}/pricing/by-dates`, { params })
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Obtener horarios flexibles */
+  getFlexibleSchedules(courseId: number, criteria: { preferredDates: string[]; flexibility: number; timeFlexibility: number; }): Observable<ScheduleOption[]> {
+    return this.http
+      .post<any>(`${this.baseUrl}/availability/flexible`, {
+        courseId,
+        ...criteria,
+      })
+      .pipe(map((res) => res.data?.options || res.data || []), catchError(this.handleError));
+  }
+
+  /** Reservar temporalmente un slot */
+  holdTimeSlot(courseId: number, date: string, timeSlotId: number, holdMinutes: number = 15): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/availability/hold`, { courseId, date, timeSlotId, holdMinutes })
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  /** Liberar slot reservado */
+  releaseHeldSlot(holdId: string): Observable<boolean> {
+    return this.http
+      .delete<any>(`${this.baseUrl}/availability/hold/${holdId}`)
+      .pipe(map((res) => !!res.success), catchError(this.handleError));
+  }
+
+  private handleError(error: any) {
+    console.error('ScheduleSelectionService Error:', error);
+    return throwError(() => error);
+  }
 }

--- a/src/app/bookings-v3/services/smart-client.service.ts
+++ b/src/app/bookings-v3/services/smart-client.service.ts
@@ -1,6 +1,66 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+import { Client, ClientSuggestion } from '../interfaces/shared.interfaces';
 
 @Injectable({ providedIn: 'root' })
 export class SmartClientService {
-  // TODO: implement real client lookup logic
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.baseUrl}/v3/clients`;
+
+  /**
+   * Búsqueda inteligente de clientes
+   */
+  searchClients(query: string): Observable<ClientSuggestion[]> {
+    const params = { q: query } as any;
+    return this.http
+      .get<any>(`${this.baseUrl}/smart-search`, { params })
+      .pipe(
+        map((res) => res.data?.results || []),
+        catchError(this.handleError)
+      );
+  }
+
+  /**
+   * Obtener clientes recientes
+   */
+  getRecentClients(limit: number = 10): Observable<Client[]> {
+    const params = { limit: limit.toString() } as any;
+    return this.http
+      .get<any>(`${this.baseUrl}/recent`, { params })
+      .pipe(
+        map((res) => res.data?.results || []),
+        catchError(this.handleError)
+      );
+  }
+
+  /**
+   * Obtener clientes favoritos
+   */
+  getFavoriteClients(limit: number = 6): Observable<Client[]> {
+    const params = { limit: limit.toString() } as any;
+    return this.http
+      .get<any>(`${this.baseUrl}/favorites`, { params })
+      .pipe(
+        map((res) => res.data?.results || []),
+        catchError(this.handleError)
+      );
+  }
+
+  /**
+   * Crear nuevo cliente
+   */
+  createClient(clientData: Partial<Client>): Observable<Client> {
+    return this.http
+      .post<any>(`${this.baseUrl}/smart-create`, clientData)
+      .pipe(map((res) => res.data), catchError(this.handleError));
+  }
+
+  private handleError(error: any) {
+    console.error('SmartClientService Error:', error);
+    return throwError(() => error);
+  }
 }


### PR DESCRIPTION
## Summary
- flesh out smart client service
- add real endpoints for activity selection
- implement schedule selection calls
- validate participant and emergency details
- connect pricing confirmation logic
- fetch analytics for clients

## Testing
- `npm test` *(fails: Ineffective mark-compacts near heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_68836bfd96648320b7f8ab54f9b249dc