### PR TITLE
Implement basic booking wizard skeleton

### DIFF
--- a/src/app/bookings-v3/bookings-v3.module.ts
+++ b/src/app/bookings-v3/bookings-v3.module.ts
@@ -41,6 +41,11 @@ import { BookingsV3RoutingModule } from './bookings-v3-routing.module';
 import { BookingWizardComponent } from './wizard/booking-wizard.component';
 import { BookingWizardDemoComponent } from './wizard/booking-wizard-demo.component';
 import { ClientSelectionStepComponent } from './wizard/steps/client-selection/client-selection-step.component';
+import { ActivitySelectionStepComponent } from './wizard/steps/activity-selection/activity-selection-step.component';
+import { ScheduleSelectionStepComponent } from './wizard/steps/schedule-selection/schedule-selection-step.component';
+import { ParticipantDetailsStepComponent } from './wizard/steps/participant-details/participant-details-step.component';
+import { PricingConfirmationStepComponent } from './wizard/steps/pricing-confirmation/pricing-confirmation-step.component';
+import { FinalReviewStepComponent } from './wizard/steps/final-review/final-review-step.component';
 
 // Services Mock (para desarrollo)
 import { MockDataService } from './services/mock/mock-data.service';
@@ -50,7 +55,12 @@ import { BOOKING_V3_PROVIDERS } from './services/service.factory';
   declarations: [
     BookingWizardComponent,
     BookingWizardDemoComponent,
-    ClientSelectionStepComponent
+    ClientSelectionStepComponent,
+    ActivitySelectionStepComponent,
+    ScheduleSelectionStepComponent,
+    ParticipantDetailsStepComponent,
+    PricingConfirmationStepComponent,
+    FinalReviewStepComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/bookings-v3/wizard/booking-wizard.component.ts
+++ b/src/app/bookings-v3/wizard/booking-wizard.component.ts
@@ -1,35 +1,37 @@
 import { Component, inject } from '@angular/core';
-import { Router } from '@angular/router';
-
-// Mock Services
-import { MockDataService } from '../services/mock/mock-data.service';
-import { SmartBookingServiceMock } from '../services/mock/smart-booking.service.mock';
+import { SMART_BOOKING_SERVICE, SMART_CLIENT_SERVICE, ACTIVITY_SELECTION_SERVICE, SCHEDULE_SELECTION_SERVICE, PARTICIPANT_DETAILS_SERVICE, PRICING_CONFIRMATION_SERVICE } from '../services/service.factory';
+import { WizardStateService } from './wizard-state.service';
 
 @Component({
   selector: 'app-booking-wizard',
   template: `
-    <div class="p-6">
-      <h1 class="text-2xl font-bold mb-4">🚀 Booking Wizard V3</h1>
-      <p class="text-gray-600 mb-4">El wizard completo se implementará próximamente.</p>
-      <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
-        <h3 class="font-semibold text-blue-800 mb-2">Componente en Desarrollo</h3>
-        <p class="text-blue-700 text-sm">
-          Este es el wizard inteligente de 6 pasos con IA, pricing dinámico y validaciones en tiempo real.
-          Por ahora, puedes probar las funcionalidades en la página de demo.
-        </p>
-        <button 
-          (click)="goToDemo()" 
-          class="inline-block mt-3 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">
-          Ir al Demo
-        </button>
+    <div class="p-6 space-y-4">
+      <h2 class="text-xl font-semibold">Booking Wizard</h2>
+      <ng-container [ngSwitch]="wizard.currentStep">
+        <app-client-selection-step *ngSwitchCase="1" (complete)="next()"></app-client-selection-step>
+        <app-activity-selection-step *ngSwitchCase="2" (complete)="next()"></app-activity-selection-step>
+        <app-schedule-selection-step *ngSwitchCase="3" (complete)="next()"></app-schedule-selection-step>
+        <app-participant-details-step *ngSwitchCase="4" (complete)="next()"></app-participant-details-step>
+        <app-pricing-confirmation-step *ngSwitchCase="5" (complete)="next()"></app-pricing-confirmation-step>
+        <app-final-review-step *ngSwitchCase="6" (complete)="reset()"></app-final-review-step>
+      </ng-container>
+      <div class="flex justify-between pt-4">
+        <button mat-button (click)="prev()" [disabled]="wizard.currentStep === 1">Back</button>
+        <span>Step {{ wizard.currentStep }} / {{ wizard.getState().totalSteps }}</span>
       </div>
     </div>
   `
 })
 export class BookingWizardComponent {
-  private router = inject(Router);
+  wizard = inject(WizardStateService);
+  bookingService = inject(SMART_BOOKING_SERVICE);
+  clientService = inject(SMART_CLIENT_SERVICE);
+  activityService = inject(ACTIVITY_SELECTION_SERVICE);
+  scheduleService = inject(SCHEDULE_SELECTION_SERVICE);
+  participantService = inject(PARTICIPANT_DETAILS_SERVICE);
+  pricingService = inject(PRICING_CONFIRMATION_SERVICE);
 
-  goToDemo() {
-    this.router.navigate(['/bookings-v3/demo']);
-  }
+  next() { this.wizard.nextStep(); }
+  prev() { this.wizard.prevStep(); }
+  reset() { this.wizard.reset(); }
 }

--- a/src/app/bookings-v3/wizard/steps/activity-selection/activity-selection-step.component.html
+++ b/src/app/bookings-v3/wizard/steps/activity-selection/activity-selection-step.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-4">
   <mat-form-field appearance="fill" class="w-full">
-    <mat-label>Client ID</mat-label>
-    <input matInput formControlName="clientId" placeholder="Enter client id">
+    <mat-label>Course</mat-label>
+    <input matInput formControlName="course" placeholder="Enter course">
   </mat-form-field>
   <button mat-raised-button color="primary" type="submit">Next</button>
 </form>

--- a/src/app/bookings-v3/wizard/steps/activity-selection/activity-selection-step.component.ts
+++ b/src/app/bookings-v3/wizard/steps/activity-selection/activity-selection-step.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Output, inject } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { ACTIVITY_SELECTION_SERVICE } from '../../../services/service.factory';
+import { WizardStateService } from '../../wizard-state.service';
+
+@Component({
+  selector: 'app-activity-selection-step',
+  templateUrl: './activity-selection-step.component.html'
+})
+export class ActivitySelectionStepComponent {
+  private fb = inject(FormBuilder);
+  private wizard = inject(WizardStateService);
+  private activityService = inject(ACTIVITY_SELECTION_SERVICE);
+
+  form: FormGroup = this.fb.group({ course: [''] });
+
+  @Output() complete = new EventEmitter<void>();
+
+  submit() {
+    this.wizard.setStepData('activity', this.form.value);
+    this.activityService.getAvailableSports?.().subscribe?.();
+    this.complete.emit();
+  }
+}

--- a/src/app/bookings-v3/wizard/steps/client-selection/client-selection-step.component.ts
+++ b/src/app/bookings-v3/wizard/steps/client-selection/client-selection-step.component.ts
@@ -1,13 +1,25 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Output, inject } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { SMART_CLIENT_SERVICE } from '../../../services/service.factory';
+import { WizardStateService } from '../../wizard-state.service';
 
 @Component({
   selector: 'app-client-selection-step',
-  template: `
-    <div class="p-4">
-      <h3>Client Selection Step</h3>
-      <p>Este componente será implementado próximamente.</p>
-    </div>
-  `
+  templateUrl: './client-selection-step.component.html'
 })
 export class ClientSelectionStepComponent {
+  private fb = inject(FormBuilder);
+  private wizard = inject(WizardStateService);
+  private clientService = inject(SMART_CLIENT_SERVICE);
+
+  form: FormGroup = this.fb.group({ clientId: [''] });
+
+  @Output() complete = new EventEmitter<void>();
+
+  submit() {
+    this.wizard.setStepData('client', this.form.value);
+    // Example integration with service
+    this.clientService.searchClients?.(this.form.value.clientId)?.subscribe?.();
+    this.complete.emit();
+  }
 }

--- a/src/app/bookings-v3/wizard/steps/final-review/final-review-step.component.html
+++ b/src/app/bookings-v3/wizard/steps/final-review/final-review-step.component.html
@@ -1,0 +1,5 @@
+<div class="space-y-4">
+  <h3>Summary</h3>
+  <pre>{{ state | json }}</pre>
+  <button mat-raised-button color="primary" (click)="finish()">Finish</button>
+</div>

--- a/src/app/bookings-v3/wizard/steps/final-review/final-review-step.component.ts
+++ b/src/app/bookings-v3/wizard/steps/final-review/final-review-step.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, Output, inject } from '@angular/core';
+import { WizardStateService } from '../../wizard-state.service';
+
+@Component({
+  selector: 'app-final-review-step',
+  templateUrl: './final-review-step.component.html'
+})
+export class FinalReviewStepComponent {
+  private wizard = inject(WizardStateService);
+
+  @Output() complete = new EventEmitter<void>();
+
+  get state() {
+    return this.wizard.getState();
+  }
+
+  finish() {
+    this.complete.emit();
+    this.wizard.reset();
+  }
+}

--- a/src/app/bookings-v3/wizard/steps/participant-details/participant-details-step.component.html
+++ b/src/app/bookings-v3/wizard/steps/participant-details/participant-details-step.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-4">
   <mat-form-field appearance="fill" class="w-full">
-    <mat-label>Client ID</mat-label>
-    <input matInput formControlName="clientId" placeholder="Enter client id">
+    <mat-label>Number of participants</mat-label>
+    <input matInput type="number" formControlName="count" min="1">
   </mat-form-field>
   <button mat-raised-button color="primary" type="submit">Next</button>
 </form>

--- a/src/app/bookings-v3/wizard/steps/participant-details/participant-details-step.component.ts
+++ b/src/app/bookings-v3/wizard/steps/participant-details/participant-details-step.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Output, inject } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { PARTICIPANT_DETAILS_SERVICE } from '../../../services/service.factory';
+import { WizardStateService } from '../../wizard-state.service';
+
+@Component({
+  selector: 'app-participant-details-step',
+  templateUrl: './participant-details-step.component.html'
+})
+export class ParticipantDetailsStepComponent {
+  private fb = inject(FormBuilder);
+  private wizard = inject(WizardStateService);
+  private participantService = inject(PARTICIPANT_DETAILS_SERVICE);
+
+  form: FormGroup = this.fb.group({ count: [1] });
+
+  @Output() complete = new EventEmitter<void>();
+
+  submit() {
+    this.wizard.setStepData('participants', this.form.value);
+    this.participantService.getSkillLevels?.().subscribe?.();
+    this.complete.emit();
+  }
+}

--- a/src/app/bookings-v3/wizard/steps/pricing-confirmation/pricing-confirmation-step.component.html
+++ b/src/app/bookings-v3/wizard/steps/pricing-confirmation/pricing-confirmation-step.component.html
@@ -1,0 +1,4 @@
+<form [formGroup]="form" (ngSubmit)="submit()" class="space-y-4">
+  <mat-checkbox formControlName="agree">I accept the price</mat-checkbox>
+  <button mat-raised-button color="primary" type="submit">Next</button>
+</form>

--- a/src/app/bookings-v3/wizard/steps/pricing-confirmation/pricing-confirmation-step.component.ts
+++ b/src/app/bookings-v3/wizard/steps/pricing-confirmation/pricing-confirmation-step.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Output, inject } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { PRICING_CONFIRMATION_SERVICE } from '../../../services/service.factory';
+import { WizardStateService } from '../../wizard-state.service';
+
+@Component({
+  selector: 'app-pricing-confirmation-step',
+  templateUrl: './pricing-confirmation-step.component.html'
+})
+export class PricingConfirmationStepComponent {
+  private fb = inject(FormBuilder);
+  private wizard = inject(WizardStateService);
+  private pricingService = inject(PRICING_CONFIRMATION_SERVICE);
+
+  form: FormGroup = this.fb.group({ agree: [false] });
+
+  @Output() complete = new EventEmitter<void>();
+
+  submit() {
+    this.wizard.setStepData('pricing', this.form.value);
+    this.pricingService.getPaymentPlans?.(0).subscribe?.();
+    this.complete.emit();
+  }
+}

--- a/src/app/bookings-v3/wizard/steps/schedule-selection/schedule-selection-step.component.html
+++ b/src/app/bookings-v3/wizard/steps/schedule-selection/schedule-selection-step.component.html
@@ -1,0 +1,9 @@
+<form [formGroup]="form" (ngSubmit)="submit()" class="space-y-4">
+  <mat-form-field appearance="fill" class="w-full">
+    <mat-label>Date</mat-label>
+    <input matInput [matDatepicker]="picker" formControlName="date">
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker #picker></mat-datepicker>
+  </mat-form-field>
+  <button mat-raised-button color="primary" type="submit">Next</button>
+</form>

--- a/src/app/bookings-v3/wizard/steps/schedule-selection/schedule-selection-step.component.ts
+++ b/src/app/bookings-v3/wizard/steps/schedule-selection/schedule-selection-step.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Output, inject } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { SCHEDULE_SELECTION_SERVICE } from '../../../services/service.factory';
+import { WizardStateService } from '../../wizard-state.service';
+
+@Component({
+  selector: 'app-schedule-selection-step',
+  templateUrl: './schedule-selection-step.component.html'
+})
+export class ScheduleSelectionStepComponent {
+  private fb = inject(FormBuilder);
+  private wizard = inject(WizardStateService);
+  private scheduleService = inject(SCHEDULE_SELECTION_SERVICE);
+
+  form: FormGroup = this.fb.group({ date: [null] });
+
+  @Output() complete = new EventEmitter<void>();
+
+  submit() {
+    this.wizard.setStepData('schedule', this.form.value);
+    this.scheduleService.getAvailabilityCalendar?.(0).subscribe?.();
+    this.complete.emit();
+  }
+}

--- a/src/app/bookings-v3/wizard/wizard-state.service.ts
+++ b/src/app/bookings-v3/wizard/wizard-state.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface WizardState {
+  currentStep: number;
+  totalSteps: number;
+  data: {
+    client?: any;
+    activity?: any;
+    schedule?: any;
+    participants?: any;
+    pricing?: any;
+  };
+}
+
+@Injectable({ providedIn: 'root' })
+export class WizardStateService {
+  private state$ = new BehaviorSubject<WizardState>({ currentStep: 1, totalSteps: 6, data: {} });
+
+  readonly stateChanges = this.state$.asObservable();
+
+  get currentStep() { return this.state$.value.currentStep; }
+
+  nextStep() {
+    const step = Math.min(this.state$.value.totalSteps, this.state$.value.currentStep + 1);
+    this.state$.next({ ...this.state$.value, currentStep: step });
+  }
+
+  prevStep() {
+    const step = Math.max(1, this.state$.value.currentStep - 1);
+    this.state$.next({ ...this.state$.value, currentStep: step });
+  }
+
+  setStepData(step: keyof WizardState['data'], value: any) {
+    this.state$.next({ ...this.state$.value, data: { ...this.state$.value.data, [step]: value } });
+  }
+
+  getState(): WizardState {
+    return this.state$.value;
+  }
+
+  reset() {
+    this.state$.next({ currentStep: 1, totalSteps: this.state$.value.totalSteps, data: {} });
+  }
+}


### PR DESCRIPTION
## Summary
- add WizardState service to hold step data
- stub simple step components for activity, schedule, participant, pricing, and review
- wire up step navigation in BookingWizardComponent
- declare new components in BookingsV3Module

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836ea91af0832086344a9f6fd7597e