### PR TITLE
Add Bookings dashboard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -42,6 +42,11 @@ const childrenRoutes: VexRoutes = [
         loadChildren: () => import('./pages/bookings-v2/bookings.module').then(m => m.BookingsModule),
         canActivate: [AuthGuard],
       },
+        {
+          path: "bookings-dashboard",
+          loadChildren: () => import("./pages/bookings-dashboard/bookings-dashboard.module").then(m => m.BookingsDashboardModule),
+          canActivate: [AuthGuard],
+        },
       {
         path: 'bookings-v3',
         loadChildren: () => import('./bookings-v3/bookings-v3.module').then(m => m.BookingsV3Module),

--- a/src/app/pages/bookings-dashboard/bookings-dashboard-routing.module.ts
+++ b/src/app/pages/bookings-dashboard/bookings-dashboard-routing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { VexRoutes } from 'src/@vex/interfaces/vex-route.interface';
+import { BookingsDashboardComponent } from './bookings-dashboard.component';
+
+const routes: VexRoutes = [
+  {
+    path: '',
+    component: BookingsDashboardComponent,
+    data: { toolbarShadowEnabled: true }
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class BookingsDashboardRoutingModule {}

--- a/src/app/pages/bookings-dashboard/bookings-dashboard.component.html
+++ b/src/app/pages/bookings-dashboard/bookings-dashboard.component.html
@@ -1,0 +1,120 @@
+<vex-page-layout>
+  <vex-secondary-toolbar current>
+    <vex-breadcrumbs [crumbs]="[
+      {icon:'reservas'},
+      {text:'bookings', title: true},
+      {text:'dashboard', subtitle: true}
+    ]" class="flex"></vex-breadcrumbs>
+  </vex-secondary-toolbar>
+
+  <vex-page-layout-content>
+    <div class="kpi-grid">
+      <mat-card>
+        <span>{{ 'total' | translate }}</span>
+        <h3>{{ kpis.total || 0 }}</h3>
+      </mat-card>
+      <mat-card>
+        <span>{{ 'confirmed' | translate }}</span>
+        <h3>{{ kpis.confirmed || 0 }}</h3>
+      </mat-card>
+      <mat-card>
+        <span>{{ 'cancelled' | translate }}</span>
+        <h3>{{ kpis.cancelled || 0 }}</h3>
+      </mat-card>
+      <mat-card>
+        <span>{{ 'revenue' | translate }}</span>
+        <h3>{{ kpis.revenue | currency }}</h3>
+      </mat-card>
+    </div>
+
+    <form class="filters" [formGroup]="filters">
+      <mat-form-field appearance="fill">
+        <mat-label>{{'type' | translate}}</mat-label>
+        <mat-select formControlName="type">
+          <mat-option value="private">Private</mat-option>
+          <mat-option value="collective">Collective</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>{{'status' | translate}}</mat-label>
+        <mat-select formControlName="status">
+          <mat-option value="confirmed">Confirmed</mat-option>
+          <mat-option value="cancelled">Cancelled</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>{{'from' | translate}}</mat-label>
+        <input matInput formControlName="start" [matDatepicker]="dp1">
+        <mat-datepicker-toggle matSuffix [for]="dp1"></mat-datepicker-toggle>
+        <mat-datepicker #dp1></mat-datepicker>
+      </mat-form-field>
+
+      <mat-form-field appearance="fill">
+        <mat-label>{{'to' | translate}}</mat-label>
+        <input matInput formControlName="end" [matDatepicker]="dp2">
+        <mat-datepicker-toggle matSuffix [for]="dp2"></mat-datepicker-toggle>
+        <mat-datepicker #dp2></mat-datepicker>
+      </mat-form-field>
+
+      <button mat-raised-button color="primary" type="button" (click)="applyFilters()">
+        {{'filter' | translate}}
+      </button>
+    </form>
+
+    <table mat-table [dataSource]="bookings" class="bookings-table">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef> ID </th>
+        <td mat-cell *matCellDef="let row"> {{row.id}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="client">
+        <th mat-header-cell *matHeaderCellDef> {{'client'|translate}} </th>
+        <td mat-cell *matCellDef="let row"> {{row.client_main?.first_name}} {{row.client_main?.last_name}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef> {{'type'|translate}} </th>
+        <td mat-cell *matCellDef="let row"> {{row.sport?.name}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="dates">
+        <th mat-header-cell *matHeaderCellDef> {{'dates'|translate}} </th>
+        <td mat-cell *matCellDef="let row"> {{row.start_date}} - {{row.end_date}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef> {{'status'|translate}} </th>
+        <td mat-cell *matCellDef="let row"> {{row.status}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="price">
+        <th mat-header-cell *matHeaderCellDef> {{'price'|translate}} </th>
+        <td mat-cell *matCellDef="let row"> {{row.price_total | currency}} </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef> {{'actions'|translate}} </th>
+        <td mat-cell *matCellDef="let row" class="actions">
+          <button mat-icon-button color="primary" (click)="goDetail(row)">
+            <mat-icon>visibility</mat-icon>
+          </button>
+          <button mat-icon-button color="accent" (click)="edit(row)">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button mat-icon-button color="warn" (click)="cancel(row)">
+            <mat-icon>cancel</mat-icon>
+          </button>
+          <button mat-icon-button (click)="openClient(row)">
+            <mat-icon>person</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+
+  </vex-page-layout-content>
+</vex-page-layout>

--- a/src/app/pages/bookings-dashboard/bookings-dashboard.component.scss
+++ b/src/app/pages/bookings-dashboard/bookings-dashboard.component.scss
@@ -1,0 +1,30 @@
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+
+  mat-card {
+    text-align: center;
+    padding: 12px;
+    background: #1e1e1e;
+    color: #fff;
+  }
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.bookings-table {
+  width: 100%;
+}
+
+.actions {
+  display: flex;
+  gap: 4px;
+}

--- a/src/app/pages/bookings-dashboard/bookings-dashboard.component.spec.ts
+++ b/src/app/pages/bookings-dashboard/bookings-dashboard.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BookingsDashboardComponent } from './bookings-dashboard.component';
+
+describe('BookingsDashboardComponent', () => {
+  let component: BookingsDashboardComponent;
+  let fixture: ComponentFixture<BookingsDashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BookingsDashboardComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BookingsDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/bookings-dashboard/bookings-dashboard.component.ts
+++ b/src/app/pages/bookings-dashboard/bookings-dashboard.component.ts
@@ -1,0 +1,66 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+import { BookingService } from 'src/service/bookings.service';
+
+@Component({
+  selector: 'vex-bookings-dashboard',
+  templateUrl: './bookings-dashboard.component.html',
+  styleUrls: ['./bookings-dashboard.component.scss']
+})
+export class BookingsDashboardComponent implements OnInit {
+  filters: FormGroup;
+  kpis: any = {};
+  bookings: any[] = [];
+  displayedColumns = ['id', 'client', 'type', 'dates', 'status', 'price', 'actions'];
+
+  constructor(private fb: FormBuilder, private bookingService: BookingService, private router: Router) {
+    this.filters = this.fb.group({
+      type: [''],
+      status: [''],
+      start: [null],
+      end: [null]
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadData();
+  }
+
+  loadData(): void {
+    const f = this.filters.value;
+    const params: any = {};
+    if (f.type) params.type = f.type;
+    if (f.status) params.status = f.status;
+    if (f.start) params.start_date = f.start;
+    if (f.end) params.end_date = f.end;
+
+    this.bookingService.getBookingsKpis(params).subscribe(res => {
+      this.kpis = res.data || res;
+    });
+
+    this.bookingService.listBookings(params).subscribe(res => {
+      this.bookings = res.data || [];
+    });
+  }
+
+  applyFilters() {
+    this.loadData();
+  }
+
+  goDetail(row: any) {
+    this.router.navigate(['/bookings/update', row.id]);
+  }
+
+  edit(row: any) {
+    this.router.navigate(['/bookings/edit', row.id]);
+  }
+
+  cancel(row: any) {
+    // Placeholder for cancellation logic
+  }
+
+  openClient(row: any) {
+    this.router.navigate(['/clients/update', row.client_main_id]);
+  }
+}

--- a/src/app/pages/bookings-dashboard/bookings-dashboard.module.ts
+++ b/src/app/pages/bookings-dashboard/bookings-dashboard.module.ts
@@ -1,0 +1,46 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LayoutModule } from '../../../@vex/layout/layout.module';
+import { PageLayoutModule } from 'src/@vex/components/page-layout/page-layout.module';
+import { BreadcrumbsModule } from 'src/@vex/components/breadcrumbs/breadcrumbs.module';
+import { RouterModule } from '@angular/router';
+import { SecondaryToolbarModule } from 'src/@vex/components/secondary-toolbar/secondary-toolbar.module';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { BookingsDashboardRoutingModule } from './bookings-dashboard-routing.module';
+import { BookingsDashboardComponent } from './bookings-dashboard.component';
+
+@NgModule({
+  declarations: [BookingsDashboardComponent],
+  imports: [
+    CommonModule,
+    LayoutModule,
+    PageLayoutModule,
+    BreadcrumbsModule,
+    RouterModule,
+    SecondaryToolbarModule,
+    MatIconModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatDatepickerModule,
+    MatCardModule,
+    MatDividerModule,
+    FormsModule,
+    ReactiveFormsModule,
+    TranslateModule,
+    BookingsDashboardRoutingModule
+  ]
+})
+export class BookingsDashboardModule {}

--- a/src/service/bookings.service.ts
+++ b/src/service/bookings.service.ts
@@ -477,6 +477,14 @@ export class BookingService {
     );
   }
 
+  listBookings(filters: any = {}): Observable<any> {
+    return this.crudService.get("/bookings", [], filters);
+  }
+
+  getBookingsKpis(filters: any = {}): Observable<any> {
+    return this.crudService.get("/bookings/kpis", [], filters);
+  }
+
   private generateRandomNumber(): string {
     return Math.random().toString(36).substring(2, 15);
   }


### PR DESCRIPTION
## Summary
- add `BookingsDashboardComponent` with KPIs, filters and bookings table
- expose `listBookings` and `getBookingsKpis` methods in `BookingService`
- register dashboard route

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837a95f530832090a2a0356e8509aa