### PR TITLE
Add mock API server and extend booking model

### DIFF
--- a/frontend-api-usage.md
+++ b/frontend-api-usage.md
@@ -123,6 +123,20 @@ interface ApiResponse {
 
 ### 6. Gestión de Reservas
 
+Los nuevos servicios de la API V3 exponen endpoints adicionales para gestionar
+reservas con filtros y creación inteligente:
+
+| Método | Endpoint | Descripción |
+|--------|----------|-------------|
+| `GET`  | `/bookings` | Listar reservas con filtros y paginación |
+| `GET`  | `/bookings/kpis` | Métricas resumidas de reservas |
+| `POST` | `/bookings` | Crear una reserva tradicional |
+| `POST` | `/bookings/smart-create` | Crear reserva con lógica inteligente |
+| `PATCH` | `/bookings/{id}` | Actualizar datos parciales de una reserva |
+| `POST` | `/bookings/{id}/cancel` | Cancelar una reserva existente |
+| `GET`  | `/clients/smart-search` | Búsqueda avanzada de clientes |
+| `POST` | `/pricing/calculate-dynamic` | Calcular precio dinámico |
+
 #### Crear log de reserva
 - **Endpoint**: `POST /booking-logs`
 - **Request**:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "node --max-old-space-size=4096 node_modules/.bin/ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "server": "node server/index.js"
   },
   "private": true,
   "engines": {
@@ -57,7 +58,8 @@
     "tinymce": "^7.5.1",
     "tslib": "^2.3.0",
     "xlsx": "^0.18.5",
-    "zone.js": "~0.13.0"
+    "zone.js": "~0.13.0",
+    "express": "^4.18.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.0.2",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,110 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+const PORT = process.env.PORT || 3000;
+const AUTH_TOKEN = 'secret-token';
+
+// Simple in-memory data
+let bookings = [];
+let bookingIdCounter = 1;
+
+function authMiddleware(req, res, next) {
+  const token = req.headers['authorization'];
+  const school = req.headers['x-school-slug'];
+  if (!token || token !== `Bearer ${AUTH_TOKEN}`) {
+    return res.status(401).json({ success: false, message: 'Unauthorized', data: [] });
+  }
+  if (!school) {
+    return res.status(400).json({ success: false, message: 'X-School-Slug header required', data: [] });
+  }
+  next();
+}
+
+function paginate(items, page = 1, perPage = 10) {
+  const offset = (page - 1) * perPage;
+  const paginatedItems = items.slice(offset, offset + perPage);
+  return {
+    success: true,
+    data: paginatedItems,
+    current_page: page,
+    per_page: perPage,
+    total: items.length,
+    message: 'Datos obtenidos exitosamente'
+  };
+}
+
+app.get('/bookings', authMiddleware, (req, res) => {
+  const { status, page = 1, perPage = 10 } = req.query;
+  let result = bookings;
+  if (status) {
+    result = result.filter(b => b.status === status);
+  }
+  res.json(paginate(result, parseInt(page), parseInt(perPage)));
+});
+
+app.get('/bookings/kpis', authMiddleware, (req, res) => {
+  const total = bookings.length;
+  const cancelled = bookings.filter(b => b.status === 'cancelled').length;
+  const active = total - cancelled;
+  res.json({
+    success: true,
+    data: { total, cancelled, active },
+    message: 'KPIs obtenidos exitosamente'
+  });
+});
+
+app.post('/bookings', authMiddleware, (req, res) => {
+  const booking = req.body;
+  booking.id = bookingIdCounter++;
+  bookings.push(booking);
+  res.status(201).json({ success: true, data: booking, message: 'Reserva creada' });
+});
+
+app.post('/bookings/smart-create', authMiddleware, (req, res) => {
+  const booking = req.body;
+  booking.smart = true;
+  booking.id = bookingIdCounter++;
+  bookings.push(booking);
+  res.status(201).json({ success: true, data: booking, message: 'Reserva inteligente creada' });
+});
+
+app.patch('/bookings/:id', authMiddleware, (req, res) => {
+  const booking = bookings.find(b => b.id === parseInt(req.params.id));
+  if (!booking) {
+    return res.status(404).json({ success: false, message: 'Booking not found', data: [] });
+  }
+  Object.assign(booking, req.body);
+  res.json({ success: true, data: booking, message: 'Reserva actualizada' });
+});
+
+app.post('/bookings/:id/cancel', authMiddleware, (req, res) => {
+  const booking = bookings.find(b => b.id === parseInt(req.params.id));
+  if (!booking) {
+    return res.status(404).json({ success: false, message: 'Booking not found', data: [] });
+  }
+  booking.status = 'cancelled';
+  booking.status_history = booking.status_history || [];
+  booking.status_history.push({ status: 'cancelled', date: new Date().toISOString() });
+  res.json({ success: true, data: booking, message: 'Reserva cancelada' });
+});
+
+app.get('/clients/smart-search', authMiddleware, (req, res) => {
+  const query = req.query.q || '';
+  // Dummy search
+  const clients = [
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob' }
+  ].filter(c => c.name.toLowerCase().includes(query.toLowerCase()));
+  res.json({ success: true, data: clients, message: 'Clientes encontrados' });
+});
+
+app.post('/pricing/calculate-dynamic', authMiddleware, (req, res) => {
+  const { base_price = 0, extras = 0 } = req.body;
+  const total = base_price + extras;
+  res.json({ success: true, data: { total }, message: 'Precio calculado' });
+});
+
+app.listen(PORT, () => {
+  console.log(`API server listening on port ${PORT}`);
+});

--- a/src/app/bookings-v3/interfaces/booking-edit.interfaces.ts
+++ b/src/app/bookings-v3/interfaces/booking-edit.interfaces.ts
@@ -67,6 +67,20 @@ export interface EnhancedBooking {
   pricing: BookingPricing;
   payments: PaymentRecord[];
   refunds: RefundRecord[];
+  /** Detalle de precios por concepto */
+  priceBreakdown: {
+    base: number;
+    extras: number;
+    tax: number;
+    total: number;
+  };
+  /** Historial de cambios de estado */
+  statusHistory: { status: string; date: string }[];
+  /** Datos agregados del cliente */
+  clientInsights: {
+    totalBookings: number;
+    lastBookingDate: Date | null;
+  };
   
   // Notas y comunicación
   notes: BookingNote[];


### PR DESCRIPTION
## Summary
- add a simple Express server exposing booking endpoints
- document new endpoints in `frontend-api-usage.md`
- expand `EnhancedBooking` interface with price breakdown, status history and client insights
- include script and dependency for the mock server

## Testing
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6883980b43188320adf7877072420041