### PR TITLE
Add tests and docs for booking wizard

### DIFF
--- a/e2e/booking-flow.spec.ts
+++ b/e2e/booking-flow.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Booking Flow', () => {
+  test('create booking via wizard', async ({ page }) => {
+    await page.goto('/bookings-v3/wizard');
+    await page.fill('[data-testid="client-search"]', 'New Client');
+    await page.click('[data-testid="create-new-client"]');
+    await page.fill('[data-testid="client-firstname"]', 'John');
+    await page.fill('[data-testid="client-lastname"]', 'Doe');
+    await page.fill('[data-testid="client-email"]', 'john@example.com');
+    await page.click('[data-testid="next-step"]');
+    await page.click('[data-testid="course-1"]');
+    await page.click('[data-testid="next-step"]');
+    await page.click('[data-testid="calendar-date-tomorrow"]');
+    await page.click('[data-testid="timeslot-morning"]');
+    await page.click('[data-testid="next-step"]');
+    await page.fill('[data-testid="participant-firstname-0"]', 'John');
+    await page.fill('[data-testid="participant-lastname-0"]', 'Doe');
+    await page.fill('[data-testid="participant-age-0"]', '25');
+    await page.selectOption('[data-testid="participant-level-0"]', 'beginner');
+    await page.click('[data-testid="next-step"]');
+    await page.click('[data-testid="accept-terms"]');
+    await page.click('[data-testid="next-step"]');
+    await page.click('[data-testid="create-booking"]');
+    await expect(page.locator('[data-testid="booking-success"]')).toBeVisible();
+  });
+
+  test('cancel booking from list', async ({ page }) => {
+    await page.goto('/bookings-v3/skipro');
+    await page.click('[data-testid="booking-row-0"] [data-testid="open-actions"]');
+    await page.click('[data-testid="cancel-booking"]');
+    await page.fill('[data-testid="cancel-reason"]', 'mistake');
+    await page.click('[data-testid="confirm-cancel"]');
+    await expect(page.locator('[data-testid="toast-success"]')).toBeVisible();
+  });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:4200',
+    headless: true
+  }
+});

--- a/frontend-api-usage.md
+++ b/frontend-api-usage.md
@@ -137,6 +137,26 @@ reservas con filtros y creación inteligente:
 | `GET`  | `/clients/smart-search` | Búsqueda avanzada de clientes |
 | `POST` | `/pricing/calculate-dynamic` | Calcular precio dinámico |
 
+#### Ejemplo de creación de reserva inteligente
+```http
+POST /bookings/smart-create
+{
+  "client_id": 1,
+  "course_id": 2,
+  "dates": ["2024-01-05"],
+  "participants": 2
+}
+```
+
+#### Ejemplo de cancelación
+```http
+POST /bookings/123/cancel
+{
+  "reason": "client_request",
+  "notifyClient": true
+}
+```
+
 #### Crear log de reserva
 - **Endpoint**: `POST /booking-logs`
 - **Request**:

--- a/src/app/bookings-v3/INTEGRATION-GUIDE.md
+++ b/src/app/bookings-v3/INTEGRATION-GUIDE.md
@@ -88,9 +88,20 @@ export const environment = {
     intelligentBooking: true,
     realTimePricing: true,
     conflictDetection: true,
-    aiRecommendations: true
+  aiRecommendations: true
   }
 };
+
+### **Activar Servicios Reales en Desarrollo**
+
+1. Cambia `useRealServices` a `true` en `src/environments/environment.ts`.
+2. Ajusta `apiUrl` al dominio de tu backend real si es necesario.
+3. Inicia la aplicación en modo producción para usar este entorno:
+
+```bash
+ng serve --configuration=production
+```
+
 
 // src/environments/environment.prod.ts
 export const environment = {

--- a/src/app/bookings-v3/QUICK-START.md
+++ b/src/app/bookings-v3/QUICK-START.md
@@ -63,6 +63,15 @@ En la página de demo puedes:
 - Calcula precios con factores múltiples
 - Ve breakdown de precios y descuentos
 
+### **4. Activar Servicios Reales**
+1. Edita `src/environments/environment.ts` y cambia `useRealServices` a `true`.
+2. Verifica que `apiUrl` apunte al backend real.
+3. Ejecuta la app en modo producción:
+
+```bash
+ng serve --configuration=production
+```
+
 ---
 
 ## **📊 Datos de Prueba Disponibles**

--- a/src/app/bookings-v3/services/smart-booking.service.spec.ts
+++ b/src/app/bookings-v3/services/smart-booking.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { SmartBookingService } from './smart-booking.service';
+import { environment } from '../../../environments/environment';
+
+describe('SmartBookingService', () => {
+  let service: SmartBookingService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [SmartBookingService]
+    });
+    service = TestBed.inject(SmartBookingService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should POST to smart-create when creating booking', fakeAsync(() => {
+    const mock = { client: { id: 1 } };
+    let result: any;
+    service.createBooking(mock as any).then(res => (result = res));
+
+    const req = http.expectOne(`${environment.baseUrl}/v2/bookings/smart-create`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ success: true, data: { id: 10 } });
+    tick();
+
+    expect(result.success).toBeTrue();
+    expect(result.data.id).toBe(10);
+  }));
+
+  it('should POST to cancel endpoint', fakeAsync(() => {
+    service.cancelBooking('5', 'test');
+    const req = http.expectOne(`${environment.baseUrl}/v2/bookings/5/cancel`);
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+    tick();
+  }));
+});

--- a/src/app/bookings-v3/wizard/wizard-state.service.spec.ts
+++ b/src/app/bookings-v3/wizard/wizard-state.service.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+import { WizardStateService } from './wizard-state.service';
+
+describe('WizardStateService', () => {
+  let service: WizardStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(WizardStateService);
+  });
+
+  it('should start on step 1', () => {
+    expect(service.currentStep).toBe(1);
+  });
+
+  it('should navigate between steps', () => {
+    service.nextStep();
+    expect(service.currentStep).toBe(2);
+    service.prevStep();
+    expect(service.currentStep).toBe(1);
+    service.prevStep();
+    expect(service.currentStep).toBe(1);
+  });
+
+  it('should reset to first step', () => {
+    service.nextStep();
+    service.nextStep();
+    service.reset();
+    expect(service.currentStep).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add SmartBookingService unit tests and wizard state tests
- provide Playwright e2e examples
- document using real services in INTEGRATION-GUIDE and QUICK-START
- show how to call smart-create and cancel endpoints in API usage guide

## Testing
- `npm test` *(fails: ng not found/OOM)*

------
https://chatgpt.com/codex/tasks/task_e_6883a2e74da0832097f19f189ff785ae