### PR TITLE
Add Angular v5 module with lazy loading

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -134,6 +134,10 @@ const routes: Routes = [
   {
     path: 'recover-password/:token',
     loadChildren: () => import('./pages/recover-password/recover-password.module').then(m => m.RecoverPasswordModule),
+  },
+  {
+    path: 'v5',
+    loadChildren: () => import('./v5/v5.module').then(m => m.V5Module)
   }
 ];
 

--- a/src/app/v5/components/welcome/welcome.component.html
+++ b/src/app/v5/components/welcome/welcome.component.html
@@ -1,0 +1,2 @@
+<h1>Welcome to Boukii v5</h1>
+<p>This is the new Angular 16+ frontend.</p>

--- a/src/app/v5/components/welcome/welcome.component.scss
+++ b/src/app/v5/components/welcome/welcome.component.scss
@@ -1,0 +1,3 @@
+h1 {
+  margin-top: 0;
+}

--- a/src/app/v5/components/welcome/welcome.component.ts
+++ b/src/app/v5/components/welcome/welcome.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-welcome',
+  templateUrl: './welcome.component.html',
+  styleUrls: ['./welcome.component.scss']
+})
+export class WelcomeComponent {}

--- a/src/app/v5/layout/v5-layout.component.html
+++ b/src/app/v5/layout/v5-layout.component.html
@@ -1,0 +1,20 @@
+<mat-sidenav-container class="v5-container">
+  <mat-sidenav #sidenav mode="side" opened class="v5-sidenav">
+    <mat-nav-list>
+      <a mat-list-item routerLink="/v5" (click)="sidenav.close()">Home</a>
+    </mat-nav-list>
+  </mat-sidenav>
+
+  <mat-sidenav-content>
+    <mat-toolbar color="primary">
+      <button mat-icon-button (click)="sidenav.toggle()">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <span>Boukii v5</span>
+    </mat-toolbar>
+
+    <div class="v5-content">
+      <router-outlet></router-outlet>
+    </div>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/app/v5/layout/v5-layout.component.scss
+++ b/src/app/v5/layout/v5-layout.component.scss
@@ -1,0 +1,7 @@
+.v5-container {
+  height: 100vh;
+}
+
+.v5-content {
+  padding: 16px;
+}

--- a/src/app/v5/layout/v5-layout.component.ts
+++ b/src/app/v5/layout/v5-layout.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-v5-layout',
+  templateUrl: './v5-layout.component.html',
+  styleUrls: ['./v5-layout.component.scss']
+})
+export class V5LayoutComponent {}

--- a/src/app/v5/v5-routing.module.ts
+++ b/src/app/v5/v5-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { V5LayoutComponent } from './layout/v5-layout.component';
+import { WelcomeComponent } from './components/welcome/welcome.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: V5LayoutComponent,
+    children: [
+      { path: '', component: WelcomeComponent }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class V5RoutingModule {}

--- a/src/app/v5/v5.module.ts
+++ b/src/app/v5/v5.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatButtonModule } from '@angular/material/button';
+import { V5RoutingModule } from './v5-routing.module';
+import { V5LayoutComponent } from './layout/v5-layout.component';
+import { WelcomeComponent } from './components/welcome/welcome.component';
+
+@NgModule({
+  declarations: [V5LayoutComponent, WelcomeComponent],
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatSidenavModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatListModule,
+    MatButtonModule,
+    V5RoutingModule
+  ]
+})
+export class V5Module {}


### PR DESCRIPTION
## Summary
- create new v5 module under `src/app/v5`
- add base layout with sidebar and topbar
- add WelcomeComponent as default page
- lazy load module from `/v5`

## Testing
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm test` *(fails: JavaScript heap out of memory)*


------
https://chatgpt.com/codex/tasks/task_e_6887c0e7d91c8320a243de620f0f9851