### PR TITLE
Add documentation skeleton for v5 angular modules

### DIFF
--- a/src/docs/v5/module-doc-template.md
+++ b/src/docs/v5/module-doc-template.md
@@ -1,0 +1,34 @@
+# Plantilla de Documentación de Módulo Angular
+
+Utiliza este esquema para documentar cada nuevo módulo bajo `src/app/v5`.
+
+## Nombre del módulo
+
+Describir brevemente la finalidad del módulo.
+
+## Componentes incluidos
+
+- `ComponenteAComponent` - Descripción breve.
+- `ComponenteBComponent` - Descripción breve.
+
+## Servicios asociados
+
+- `ServicioAService` - Qué datos maneja o de dónde obtiene la información.
+- `ServicioBService` - Propósito principal.
+
+## Ejemplo de uso
+
+```html
+<!-- Ejemplo de invocación de un componente principal -->
+<app-componente-a></app-componente-a>
+```
+
+## Captura opcional
+
+_Incluir una imagen si aporta valor visual al módulo._
+
+## Cómo probar en frontend
+
+1. Ejecutar `npm start`.
+2. Navegar a `http://localhost:4200/v5/<ruta-del-modulo>`.
+3. Comprobar que los componentes se muestran correctamente y que los servicios funcionan según lo esperado.

--- a/src/docs/v5/v5-overview.md
+++ b/src/docs/v5/v5-overview.md
@@ -1,0 +1,34 @@
+# Boukii v5 - Overview
+
+Esta documentación describe la nueva infraestructura Angular ubicada en `src/app/v5`.
+Para la planificación completa consulta `boukii-5.0.md`.
+
+## Estructura modular
+
+```
+src/app/v5/
+├── components/
+│   └── welcome/              # Componente inicial
+├── layout/
+│   └── v5-layout.component.* # Layout base con sidenav y toolbar
+├── v5-routing.module.ts      # Rutas hijas
+└── v5.module.ts              # Módulo principal
+```
+
+Cada futura funcionalidad (dashboard, bookings, etc.) se añadirá como un módulo hijo bajo esta carpeta y se cargará de forma lazy.
+
+## Lazy loading y nuevo layout
+
+El `AppRoutingModule` carga `V5Module` de forma perezosa cuando se navega a `/v5`. Dentro de este módulo, `V5LayoutComponent` provee la estructura de navegación (sidenav + toolbar) para todos los componentes hijos.
+
+## Composición de componentes
+
+`WelcomeComponent` es el primer componente cargado. Los siguientes módulos seguirán el mismo patrón: un módulo por funcionalidad con sus propios componentes y servicios.
+
+## Pruebas visuales
+
+Para validar cada módulo se recomienda ejecutar `npm start` y navegar a la ruta correspondiente. Se puede usar la extensión de Angular DevTools para inspeccionar el árbol de componentes.
+
+## Ruta inicial
+
+La ruta por defecto es `/v5/welcome` (o simplemente `/v5`) que muestra el `WelcomeComponent` dentro del nuevo layout.

--- a/src/docs/v5/welcome.md
+++ b/src/docs/v5/welcome.md
@@ -1,0 +1,27 @@
+# WelcomeComponent
+
+Este componente da la bienvenida a Boukii v5 y sirve como punto de partida para validar la nueva arquitectura.
+
+## Funcionalidad
+
+- Muestra un mensaje estático con título y descripción.
+- No consume servicios ni depende de datos externos actualmente.
+
+## Ruta de acceso
+
+- **`/v5/welcome`** (también accesible desde `/v5`). El `V5RoutingModule` lo define como hijo directo del layout.
+
+## Estructura
+
+```
+src/app/v5/components/welcome/
+├── welcome.component.ts
+├── welcome.component.html
+└── welcome.component.scss
+```
+
+## Cómo probar
+
+1. Ejecutar `npm start`.
+2. Navegar a `http://localhost:4200/v5/welcome`.
+3. Verificar que se muestra el mensaje de bienvenida dentro del layout con sidenav.


### PR DESCRIPTION
## Summary
- create `src/docs/v5/` directory
- document the new `/v5` module structure and routing
- provide docs for `WelcomeComponent`
- add a template to document future angular modules

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c9c531d08320a9f6bdb32ea9489d