### PR TITLE
Add v5 core service stubs

### DIFF
--- a/src/app/v5/core/services/api-v5.service.ts
+++ b/src/app/v5/core/services/api-v5.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ApiV5Service {
+  constructor() {}
+}

--- a/src/app/v5/core/services/auth-v5.service.ts
+++ b/src/app/v5/core/services/auth-v5.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AuthV5Service {
+  constructor() {}
+}

--- a/src/app/v5/core/services/loading.service.ts
+++ b/src/app/v5/core/services/loading.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class LoadingService {
+  constructor() {}
+}

--- a/src/app/v5/core/services/notification.service.ts
+++ b/src/app/v5/core/services/notification.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  constructor() {}
+}

--- a/src/app/v5/core/services/season-context.service.ts
+++ b/src/app/v5/core/services/season-context.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SeasonContextService {
+  constructor() {}
+}

--- a/src/app/v5/v5.module.ts
+++ b/src/app/v5/v5.module.ts
@@ -11,6 +11,11 @@ import { V5LayoutComponent } from './layout/v5-layout.component';
 import { WelcomeComponent } from './pages/welcome/welcome.component';
 import { NavbarComponent } from './components/navbar/navbar.component';
 import { SidebarComponent } from './components/sidebar/sidebar.component';
+import { ApiV5Service } from './core/services/api-v5.service';
+import { SeasonContextService } from './core/services/season-context.service';
+import { AuthV5Service } from './core/services/auth-v5.service';
+import { NotificationService } from './core/services/notification.service';
+import { LoadingService } from './core/services/loading.service';
 
 @NgModule({
   declarations: [
@@ -28,6 +33,13 @@ import { SidebarComponent } from './components/sidebar/sidebar.component';
     MatListModule,
     MatButtonModule,
     V5RoutingModule
+  ],
+  providers: [
+    ApiV5Service,
+    SeasonContextService,
+    AuthV5Service,
+    NotificationService,
+    LoadingService
   ]
 })
 export class V5Module {}


### PR DESCRIPTION
## Summary
- add new Angular services under `v5/core/services`
- provide the new services from `V5Module`

## Testing
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6887ea23ed9c83208830010efcfde5bc