### PR TITLE
Add v5 core model interfaces

### DIFF
--- a/src/app/pages/bookings-v2/bookings-create-update/components/create-user-dialog/create-user-dialog.component.ts
+++ b/src/app/pages/bookings-v2/bookings-create-update/components/create-user-dialog/create-user-dialog.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit } from "@angular/core";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Observable } from "rxjs";
-import { ApiResponse } from "src/app/interface/api-response";
+import { ApiResponse } from "src/app/v5/core/models/api-response.interface";
 import { ApiCrudService } from "src/service/crud.service";
 import { LangService } from "src/service/langService";
 

--- a/src/app/pages/bookings-v2/bookings-create-update/components/step-one/step-one.component.ts
+++ b/src/app/pages/bookings-v2/bookings-create-update/components/step-one/step-one.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit, Output, EventEmitter } from "@angular/core";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { Observable, debounceTime, map, skip, startWith } from "rxjs";
 import { ApiCrudService } from "src/service/crud.service";
-import { ApiResponse } from "src/app/interface/api-response";
+import { ApiResponse } from "src/app/v5/core/models/api-response.interface";
 import { MatDialog } from '@angular/material/dialog';
 import { UtilsService } from '../../../../../../service/utils.service';
 import { switchMap } from 'rxjs/operators';

--- a/src/app/v5/core/models/api-response.interface.ts
+++ b/src/app/v5/core/models/api-response.interface.ts
@@ -1,0 +1,5 @@
+export interface ApiResponse<T = any> {
+  data: T;
+  success: boolean;
+  message: string;
+}

--- a/src/app/v5/core/models/common.interface.ts
+++ b/src/app/v5/core/models/common.interface.ts
@@ -1,0 +1,6 @@
+export interface Common {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at?: string | null;
+}

--- a/src/app/v5/core/models/season.interface.ts
+++ b/src/app/v5/core/models/season.interface.ts
@@ -1,0 +1,11 @@
+export interface Season {
+  id: number;
+  name: string;
+  start_date: string;
+  end_date: string;
+  is_active: boolean;
+  is_closed: boolean;
+  is_historical: boolean;
+  school_id: number;
+  created_at: string;
+}

--- a/src/service/crud.service.ts
+++ b/src/service/crud.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApiService } from './api.service';
-import { ApiResponse } from 'src/app/interface/api-response';
+import { ApiResponse } from 'src/app/v5/core/models/api-response.interface';
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
## Summary
- add interfaces for seasons, generic API responses and common entity fields
- adjust imports in CRUD service and booking components to new paths

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688881ba47d883209601bd964d4e2c5a