### PR TITLE
Add NgRx state for seasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@kolkov/angular-editor": "^3.0.0-beta.0",
     "@material-design-icons/svg": "^0.14.3",
     "@ngneat/until-destroy": "~9.2.3",
+    "@ngrx/effects": "^16.0.0",
+    "@ngrx/store": "^16.0.0",
     "@ngx-loading-bar/core": "^6.0.2",
     "@ngx-loading-bar/router": "^6.0.2",
     "@ngx-translate/core": "^15.0.0",
@@ -39,6 +41,7 @@
     "angularx-qrcode": "^17.0.0",
     "apexcharts": "~3.44.0",
     "date-fns": "~2.30.0",
+    "express": "^4.18.4",
     "file-saver": "^2.0.5",
     "highlight.js": "~11.9.0",
     "jspdf": "^2.5.1",
@@ -58,8 +61,7 @@
     "tinymce": "^7.5.1",
     "tslib": "^2.3.0",
     "xlsx": "^0.18.5",
-    "zone.js": "~0.13.0",
-    "express": "^4.18.4"
+    "zone.js": "~0.13.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.0.2",

--- a/src/app/v5/core/services/season-context.service.ts
+++ b/src/app/v5/core/services/season-context.service.ts
@@ -1,10 +1,22 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Season } from '../models/season.interface';
 
 @Injectable({ providedIn: 'root' })
 export class SeasonContextService {
+  private currentSeasonSubject = new BehaviorSubject<Season | null>(null);
+  readonly currentSeason$ = this.currentSeasonSubject.asObservable();
+
   constructor() {}
 
+  setCurrentSeason(season: Season): void {
+    this.currentSeasonSubject.next(season);
+    window.dispatchEvent(
+      new CustomEvent('boukii-season-changed', { detail: { season } })
+    );
+  }
+
   getCurrentSeasonId(): number | null {
-    return null;
+    return this.currentSeasonSubject.value?.id || null;
   }
 }

--- a/src/app/v5/features/seasons/seasons.module.ts
+++ b/src/app/v5/features/seasons/seasons.module.ts
@@ -5,6 +5,10 @@ import { SeasonsRoutingModule } from './seasons-routing.module';
 import { SeasonListComponent } from './pages/season-list/season-list.component';
 import { SeasonFormComponent } from './pages/season-form/season-form.component';
 import { SeasonDetailComponent } from './pages/season-detail/season-detail.component';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { seasonFeatureKey, seasonReducer } from './state/season.state';
+import { SeasonEffects } from './state/season.effects';
 
 
 @NgModule({
@@ -15,7 +19,9 @@ import { SeasonDetailComponent } from './pages/season-detail/season-detail.compo
   ],
   imports: [
     CommonModule,
-    SeasonsRoutingModule
+    SeasonsRoutingModule,
+    StoreModule.forFeature(seasonFeatureKey, seasonReducer),
+    EffectsModule.forFeature([SeasonEffects])
   ]
 })
 export class SeasonsModule { }

--- a/src/app/v5/features/seasons/state/season.actions.ts
+++ b/src/app/v5/features/seasons/state/season.actions.ts
@@ -1,0 +1,19 @@
+import { createAction, props } from '@ngrx/store';
+import { Season } from '../../../core/models/season.interface';
+
+export const loadSeasons = createAction('[Season] Load Seasons');
+
+export const loadSeasonsSuccess = createAction(
+  '[Season] Load Seasons Success',
+  props<{ seasons: Season[] }>()
+);
+
+export const loadSeasonsFailure = createAction(
+  '[Season] Load Seasons Failure',
+  props<{ error: any }>()
+);
+
+export const setCurrentSeason = createAction(
+  '[Season] Set Current Season',
+  props<{ season: Season }>()
+);

--- a/src/app/v5/features/seasons/state/season.effects.ts
+++ b/src/app/v5/features/seasons/state/season.effects.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import * as SeasonActions from './season.actions';
+import { SeasonService } from '../services/season.service';
+import { SeasonContextService } from '../../core/services/season-context.service';
+
+@Injectable()
+export class SeasonEffects {
+  loadSeasons$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(SeasonActions.loadSeasons),
+      switchMap(() =>
+        this.seasonService.getSeasons().pipe(
+          map(seasons => SeasonActions.loadSeasonsSuccess({ seasons })),
+          catchError(error => of(SeasonActions.loadSeasonsFailure({ error })))
+        )
+      )
+    )
+  );
+
+  setCurrentSeason$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(SeasonActions.setCurrentSeason),
+        tap(action => this.seasonContext.setCurrentSeason(action.season))
+      ),
+    { dispatch: false }
+  );
+
+  constructor(
+    private actions$: Actions,
+    private seasonService: SeasonService,
+    private seasonContext: SeasonContextService
+  ) {}
+}

--- a/src/app/v5/features/seasons/state/season.selectors.ts
+++ b/src/app/v5/features/seasons/state/season.selectors.ts
@@ -1,0 +1,19 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { seasonFeatureKey, SeasonState } from './season.state';
+
+export const selectSeasonState = createFeatureSelector<SeasonState>(seasonFeatureKey);
+
+export const selectCurrentSeason = createSelector(
+  selectSeasonState,
+  state => state.currentSeason
+);
+
+export const selectAllSeasons = createSelector(
+  selectSeasonState,
+  state => state.seasons
+);
+
+export const selectSeasonsLoading = createSelector(
+  selectSeasonState,
+  state => state.loading
+);

--- a/src/app/v5/features/seasons/state/season.state.ts
+++ b/src/app/v5/features/seasons/state/season.state.ts
@@ -1,0 +1,39 @@
+import { createReducer, on } from '@ngrx/store';
+import { Season } from '../../../core/models/season.interface';
+import * as SeasonActions from './season.actions';
+
+export const seasonFeatureKey = 'season';
+
+export interface SeasonState {
+  currentSeason: Season | null;
+  seasons: Season[];
+  loading: boolean;
+  error: any;
+}
+
+export const initialState: SeasonState = {
+  currentSeason: null,
+  seasons: [],
+  loading: false,
+  error: null
+};
+
+export const seasonReducer = createReducer(
+  initialState,
+  on(SeasonActions.loadSeasons, state => ({ ...state, loading: true })),
+  on(SeasonActions.loadSeasonsSuccess, (state, { seasons }) => ({
+    ...state,
+    seasons,
+    loading: false,
+    error: null
+  })),
+  on(SeasonActions.loadSeasonsFailure, (state, { error }) => ({
+    ...state,
+    loading: false,
+    error
+  })),
+  on(SeasonActions.setCurrentSeason, (state, { season }) => ({
+    ...state,
+    currentSeason: season
+  }))
+);

--- a/src/app/v5/v5.module.ts
+++ b/src/app/v5/v5.module.ts
@@ -6,6 +6,8 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatButtonModule } from '@angular/material/button';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
 import { V5RoutingModule } from './v5-routing.module';
 import { V5LayoutComponent } from './layout/v5-layout.component';
 import { WelcomeComponent } from './pages/welcome/welcome.component';
@@ -36,6 +38,8 @@ import { SeasonsModule } from './features/seasons/seasons.module';
     MatIconModule,
     MatListModule,
     MatButtonModule,
+    StoreModule.forRoot({}),
+    EffectsModule.forRoot([]),
     V5RoutingModule,
     SeasonsModule
   ],


### PR DESCRIPTION
## Summary
- add NgRx store and effects for seasons
- integrate SeasonContextService with global store
- hook store into V5 module and seasons feature module

## Testing
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6888853285cc83209b2f6f19a8f4bda5