### PR TITLE
Implement v5 core service functionality

### DIFF
--- a/src/app/v5/core/services/api-v5.service.ts
+++ b/src/app/v5/core/services/api-v5.service.ts
@@ -1,6 +1,78 @@
 import { Injectable } from '@angular/core';
+import {
+  HttpClient,
+  HttpHeaders,
+  HttpParams,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError, shareReplay } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import { SeasonContextService } from './season-context.service';
+import { NotificationService } from './notification.service';
 
 @Injectable({ providedIn: 'root' })
 export class ApiV5Service {
-  constructor() {}
+  private baseUrlV5 = `${environment.baseUrl}/admin_v3`;
+
+  constructor(
+    private http: HttpClient,
+    private seasonContext: SeasonContextService,
+    private notification: NotificationService
+  ) {}
+
+  private getHeaders(): HttpHeaders {
+    const token = localStorage.getItem('boukiiUserToken');
+    const seasonId = this.seasonContext.getCurrentSeasonId();
+
+    let headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+    if (token) {
+      headers = headers.set('Authorization', `Bearer ${token}`);
+    }
+    if (seasonId !== null) {
+      headers = headers.set('X-Season-Id', String(seasonId));
+    }
+    return headers.set('X-Client-Version', 'boukii-admin-v5.0');
+  }
+
+  get<T>(endpoint: string, params?: HttpParams): Observable<T> {
+    return this.http
+      .get<T>(`${this.baseUrlV5}/${endpoint}`, {
+        headers: this.getHeaders(),
+        params: this.addSeasonParam(params),
+      })
+      .pipe(catchError((e) => this.handleError(e)), shareReplay(1));
+  }
+
+  post<T>(endpoint: string, body: any): Observable<T> {
+    const enrichedBody = {
+      ...body,
+      season_id: this.seasonContext.getCurrentSeasonId(),
+    };
+
+    return this.http
+      .post<T>(`${this.baseUrlV5}/${endpoint}`, enrichedBody, {
+        headers: this.getHeaders(),
+      })
+      .pipe(catchError((e) => this.handleError(e)));
+  }
+
+  private addSeasonParam(params?: HttpParams): HttpParams {
+    const seasonId = this.seasonContext.getCurrentSeasonId();
+    if (!params) {
+      params = new HttpParams();
+    }
+    if (seasonId !== null) {
+      params = params.set('season_id', seasonId.toString());
+    }
+    return params;
+  }
+
+  private handleError(error: HttpErrorResponse): Observable<never> {
+    if (error.status === 422 && (error as any).error?.season_required) {
+      this.seasonContext.promptSeasonSelection();
+    }
+    this.notification.error('Error al comunicarse con el servidor');
+    return throwError(() => error);
+  }
 }

--- a/src/app/v5/core/services/auth-v5.service.ts
+++ b/src/app/v5/core/services/auth-v5.service.ts
@@ -1,10 +1,30 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class AuthV5Service {
-  constructor() {}
+  private tokenKey = 'boukiiUserToken';
+
+  constructor(private http: HttpClient) {}
+
+  login(credentials: { email: string; password: string }): Observable<any> {
+    return this.http
+      .post<any>(`${environment.baseUrl}/admin_v3/login`, credentials)
+      .pipe(tap((res) => localStorage.setItem(this.tokenKey, res.token)));
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.tokenKey);
+  }
 
   getToken(): string | null {
-    return null;
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.getToken();
   }
 }

--- a/src/app/v5/core/services/loading.service.ts
+++ b/src/app/v5/core/services/loading.service.ts
@@ -1,10 +1,27 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class LoadingService {
+  private loadingSubject = new BehaviorSubject<boolean>(false);
+  readonly loading$ = this.loadingSubject.asObservable();
+  private counter = 0;
+
   constructor() {}
 
-  start(): void {}
+  start(): void {
+    this.counter++;
+    if (this.counter === 1) {
+      this.loadingSubject.next(true);
+    }
+  }
 
-  stop(): void {}
+  stop(): void {
+    if (this.counter > 0) {
+      this.counter--;
+      if (this.counter === 0) {
+        this.loadingSubject.next(false);
+      }
+    }
+  }
 }

--- a/src/app/v5/core/services/notification.service.ts
+++ b/src/app/v5/core/services/notification.service.ts
@@ -1,6 +1,43 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+export interface Notification {
+  type: 'success' | 'error' | 'info' | 'warning';
+  message: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class NotificationService {
-  constructor() {}
+  private notificationsSubject = new BehaviorSubject<Notification[]>([]);
+  readonly notifications$ = this.notificationsSubject.asObservable();
+
+  constructor(private snackBar: MatSnackBar) {}
+
+  success(message: string, duration = 3000): void {
+    this.show('success', message, duration);
+  }
+
+  error(message: string, duration = 5000): void {
+    this.show('error', message, duration);
+  }
+
+  info(message: string, duration = 3000): void {
+    this.show('info', message, duration);
+  }
+
+  warning(message: string, duration = 4000): void {
+    this.show('warning', message, duration);
+  }
+
+  private show(type: Notification['type'], message: string, duration: number) {
+    const list = this.notificationsSubject.value;
+    this.notificationsSubject.next([...list, { type, message }]);
+    this.snackBar.open(message, 'Cerrar', {
+      duration,
+      panelClass: [`snackbar-${type}`],
+      horizontalPosition: 'end',
+      verticalPosition: 'top',
+    });
+  }
 }

--- a/src/app/v5/core/services/season-context.service.ts
+++ b/src/app/v5/core/services/season-context.service.ts
@@ -1,22 +1,98 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { Season } from '../models/season.interface';
+import { ApiV5Service } from './api-v5.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({ providedIn: 'root' })
 export class SeasonContextService {
   private currentSeasonSubject = new BehaviorSubject<Season | null>(null);
-  readonly currentSeason$ = this.currentSeasonSubject.asObservable();
+  private availableSeasonsSubject = new BehaviorSubject<Season[]>([]);
+  private loadingSubject = new BehaviorSubject<boolean>(false);
 
-  constructor() {}
+  readonly currentSeason$ = this.currentSeasonSubject.asObservable();
+  readonly availableSeasons$ = this.availableSeasonsSubject.asObservable();
+  readonly loading$ = this.loadingSubject.asObservable();
+
+  constructor(private apiV5: ApiV5Service, private snackBar: MatSnackBar) {
+    this.initializeSeasonContext();
+  }
 
   setCurrentSeason(season: Season): void {
+    const previousSeason = this.currentSeasonSubject.value;
     this.currentSeasonSubject.next(season);
+    localStorage.setItem('boukii_current_season', JSON.stringify(season));
     window.dispatchEvent(
-      new CustomEvent('boukii-season-changed', { detail: { season } })
+      new CustomEvent('boukii-season-changed', {
+        detail: { previousSeason, currentSeason: season, timestamp: Date.now() },
+      })
     );
+    this.snackBar.open(`Temporada cambiada a: ${season.name}`, 'OK', {
+      duration: 3000,
+    });
   }
 
   getCurrentSeasonId(): number | null {
     return this.currentSeasonSubject.value?.id || null;
+  }
+
+  getCurrentSeason(): Season | null {
+    return this.currentSeasonSubject.value;
+  }
+
+  canEditCurrentSeason(): boolean {
+    const season = this.getCurrentSeason();
+    return !!season && !season.is_closed && !season.is_historical;
+  }
+
+  promptSeasonSelection(): void {
+    this.snackBar.open('Seleccione una temporada', 'OK', { duration: 3000 });
+  }
+
+  private async initializeSeasonContext(): Promise<void> {
+    try {
+      this.loadingSubject.next(true);
+      await this.loadAvailableSeasons();
+      await this.initializeCurrentSeason();
+    } finally {
+      this.loadingSubject.next(false);
+    }
+  }
+
+  private async loadAvailableSeasons(): Promise<void> {
+    try {
+      const seasons = await this.apiV5
+        .get<Season[]>('seasons/available')
+        .toPromise();
+      this.availableSeasonsSubject.next(seasons || []);
+    } catch (error) {
+      console.error('Error loading seasons:', error);
+      this.availableSeasonsSubject.next([]);
+    }
+  }
+
+  private async initializeCurrentSeason(): Promise<void> {
+    const stored = localStorage.getItem('boukii_current_season');
+    if (stored) {
+      try {
+        const season = JSON.parse(stored);
+        this.currentSeasonSubject.next(season);
+        return;
+      } catch {
+        localStorage.removeItem('boukii_current_season');
+      }
+    }
+
+    const seasons = this.availableSeasonsSubject.value;
+    const activeSeason = seasons.find((s) => s.is_active);
+    if (activeSeason) {
+      this.setCurrentSeason(activeSeason);
+    } else if (seasons.length > 0) {
+      const mostRecent = [...seasons].sort(
+        (a, b) =>
+          new Date(b.start_date).getTime() - new Date(a.start_date).getTime()
+      )[0];
+      this.setCurrentSeason(mostRecent);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- implement ApiV5Service with token and season headers
- expand SeasonContextService with season persistence and loading
- implement AuthV5Service login/logout helpers
- add NotificationService with snackbar dispatch
- add LoadingService with observable indicator

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888775839c8320a2d274acd73e52d4