### PR TITLE
Implement AuthV5Service season handling

### DIFF
--- a/src/app/v5/core/services/auth-v5.service.ts
+++ b/src/app/v5/core/services/auth-v5.service.ts
@@ -1,30 +1,83 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { tap } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { tap, map } from 'rxjs/operators';
+import { Observable, BehaviorSubject } from 'rxjs';
 import { environment } from 'src/environments/environment';
+import { SeasonContextService } from './season-context.service';
+import { Season } from '../models/season.interface';
+
+export interface LoginResponse {
+  token: string;
+  user: any;
+  active_season?: Season;
+}
 
 @Injectable({ providedIn: 'root' })
 export class AuthV5Service {
   private tokenKey = 'boukiiUserToken';
+  private userKey = 'boukiiUser';
 
-  constructor(private http: HttpClient) {}
+  private tokenSubject = new BehaviorSubject<string | null>(
+    localStorage.getItem(this.tokenKey)
+  );
+  readonly token$ = this.tokenSubject.asObservable();
 
-  login(credentials: { email: string; password: string }): Observable<any> {
+  private userSubject = new BehaviorSubject<any | null>(this.getStoredUser());
+  readonly user$ = this.userSubject.asObservable();
+
+  readonly isAuthenticated$ = this.token$.pipe(map((t) => !!t));
+
+  constructor(
+    private http: HttpClient,
+    private seasonContext: SeasonContextService
+  ) {}
+
+  login(credentials: { email: string; password: string }): Observable<LoginResponse> {
     return this.http
-      .post<any>(`${environment.baseUrl}/admin_v3/login`, credentials)
-      .pipe(tap((res) => localStorage.setItem(this.tokenKey, res.token)));
+      .post<LoginResponse>(`${environment.baseUrl}/admin_v3/login`, credentials)
+      .pipe(
+        tap((res) => {
+          localStorage.setItem(this.tokenKey, res.token);
+          this.tokenSubject.next(res.token);
+
+          if (res.user) {
+            localStorage.setItem(this.userKey, JSON.stringify(res.user));
+            this.userSubject.next(res.user);
+          }
+
+          if (res.active_season) {
+            this.seasonContext.setCurrentSeason(res.active_season);
+          }
+        })
+      );
   }
 
   logout(): void {
     localStorage.removeItem(this.tokenKey);
+    localStorage.removeItem(this.userKey);
+    this.tokenSubject.next(null);
+    this.userSubject.next(null);
   }
 
   getToken(): string | null {
-    return localStorage.getItem(this.tokenKey);
+    return this.tokenSubject.value;
   }
 
   isAuthenticated(): boolean {
-    return !!this.getToken();
+    return !!this.tokenSubject.value;
+  }
+
+  hasPermission(permission: string): boolean {
+    const user = this.userSubject.value as any;
+    return Array.isArray(user?.permissions) && user.permissions.includes(permission);
+  }
+
+  private getStoredUser(): any | null {
+    const stored = localStorage.getItem(this.userKey);
+    try {
+      return stored ? JSON.parse(stored) : null;
+    } catch {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- upgrade AuthV5Service to manage token, user and season
- store login response data and update SeasonContext
- expose observables and permission checks

## Testing
- `npm test` *(fails: Ineffective mark-compacts near heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_68889a4bd40c83209516446e41e6d1df