### PR TITLE
Add reusable form utilities

### DIFF
--- a/src/app/v5/core/services/form-builder.service.ts
+++ b/src/app/v5/core/services/form-builder.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { FormBuilder, AbstractControlOptions, FormGroup, FormArray, FormControl } from '@angular/forms';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FormBuilderService {
+  constructor(private fb: FormBuilder) {}
+
+  group(controlsConfig: {[key: string]: any}, options?: AbstractControlOptions): FormGroup {
+    return this.fb.group(controlsConfig, options);
+  }
+
+  control(formState: any, validatorOrOpts?: any, asyncValidator?: any): FormControl {
+    return this.fb.control(formState, validatorOrOpts, asyncValidator);
+  }
+
+  array(controls: any[], validatorOrOpts?: any, asyncValidator?: any): FormArray {
+    return this.fb.array(controls, validatorOrOpts, asyncValidator);
+  }
+}

--- a/src/app/v5/core/utils/validators.ts
+++ b/src/app/v5/core/utils/validators.ts
@@ -1,0 +1,19 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function requiredTrimmed(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = (control.value || '').toString().trim();
+    return value ? null : { required: true };
+  };
+}
+
+export function matchValidator(matchTo: string): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const parent = control.parent;
+    if (!parent) {
+      return null;
+    }
+    const matching = parent.get(matchTo);
+    return matching && control.value === matching.value ? null : { matching: true };
+  };
+}

--- a/src/app/v5/features/schools/components/season-settings-form/season-settings-form.component.html
+++ b/src/app/v5/features/schools/components/season-settings-form/season-settings-form.component.html
@@ -1,1 +1,4 @@
-<p>season-settings-form works!</p>
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <vex-form-field label="Description" [control]="form.get('description')"></vex-form-field>
+  <button type="submit" [disabled]="form.invalid">Save</button>
+</form>

--- a/src/app/v5/features/schools/components/season-settings-form/season-settings-form.component.ts
+++ b/src/app/v5/features/schools/components/season-settings-form/season-settings-form.component.ts
@@ -1,8 +1,25 @@
 import { Component } from '@angular/core';
+import { FormGroup, Validators } from '@angular/forms';
+import { FormBuilderService } from '../../../core/services/form-builder.service';
+import { requiredTrimmed } from '../../../core/utils/validators';
 
 @Component({
   selector: 'vex-season-settings-form',
   templateUrl: './season-settings-form.component.html',
   styleUrls: ['./season-settings-form.component.scss']
 })
-export class SeasonSettingsFormComponent {}
+export class SeasonSettingsFormComponent {
+  form: FormGroup;
+
+  constructor(private fbs: FormBuilderService) {
+    this.form = this.fbs.group({
+      description: ['', [Validators.required, requiredTrimmed()]]
+    });
+  }
+
+  submit(): void {
+    if (this.form.valid) {
+      console.log(this.form.value);
+    }
+  }
+}

--- a/src/app/v5/features/schools/schools.module.ts
+++ b/src/app/v5/features/schools/schools.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
 import { SharedModule } from '../../shared/shared.module';
 
 import { SchoolsRoutingModule } from './schools-routing.module';
@@ -24,6 +25,7 @@ import { SeasonSettingsFormComponent } from './components/season-settings-form/s
   imports: [
     CommonModule,
     SchoolsRoutingModule,
+    ReactiveFormsModule,
     SharedModule
   ]
 })

--- a/src/app/v5/features/seasons/pages/season-form/season-form.component.html
+++ b/src/app/v5/features/seasons/pages/season-form/season-form.component.html
@@ -1,1 +1,4 @@
-<p>season-form works!</p>
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <vex-form-field label="Name" [control]="form.get('name')"></vex-form-field>
+  <button type="submit" [disabled]="form.invalid">Save</button>
+</form>

--- a/src/app/v5/features/seasons/pages/season-form/season-form.component.ts
+++ b/src/app/v5/features/seasons/pages/season-form/season-form.component.ts
@@ -1,4 +1,7 @@
 import { Component } from '@angular/core';
+import { FormGroup, Validators } from '@angular/forms';
+import { FormBuilderService } from '../../../core/services/form-builder.service';
+import { requiredTrimmed } from '../../../core/utils/validators';
 
 @Component({
   selector: 'vex-season-form',
@@ -6,5 +9,17 @@ import { Component } from '@angular/core';
   styleUrls: ['./season-form.component.scss']
 })
 export class SeasonFormComponent {
+  form: FormGroup;
 
+  constructor(private fbs: FormBuilderService) {
+    this.form = this.fbs.group({
+      name: ['', [Validators.required, requiredTrimmed()]]
+    });
+  }
+
+  submit(): void {
+    if (this.form.valid) {
+      console.log(this.form.value);
+    }
+  }
 }

--- a/src/app/v5/features/seasons/seasons.module.ts
+++ b/src/app/v5/features/seasons/seasons.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
 import { SharedModule } from '../../shared/shared.module';
 
 import { SeasonsRoutingModule } from './seasons-routing.module';
@@ -23,6 +24,7 @@ import { SeasonEffects } from './state/season.effects';
     SeasonsRoutingModule,
     StoreModule.forFeature(seasonFeatureKey, seasonReducer),
     EffectsModule.forFeature([SeasonEffects]),
+    ReactiveFormsModule,
     SharedModule
   ]
 })

--- a/src/app/v5/shared/forms/form-field.component.html
+++ b/src/app/v5/shared/forms/form-field.component.html
@@ -1,0 +1,5 @@
+<div class="form-field">
+  <label *ngIf="label">{{ label }}</label>
+  <input [formControl]="control" [type]="type" class="form-input" />
+  <ng-content></ng-content>
+</div>

--- a/src/app/v5/shared/forms/form-field.component.scss
+++ b/src/app/v5/shared/forms/form-field.component.scss
@@ -1,0 +1,11 @@
+.form-field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.form-input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/src/app/v5/shared/forms/form-field.component.ts
+++ b/src/app/v5/shared/forms/form-field.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { AbstractControl } from '@angular/forms';
+
+@Component({
+  selector: 'vex-form-field',
+  templateUrl: './form-field.component.html',
+  styleUrls: ['./form-field.component.scss']
+})
+export class FormFieldComponent {
+  @Input() label = '';
+  @Input() control: AbstractControl | null = null;
+  @Input() type = 'text';
+}

--- a/src/app/v5/shared/shared.module.ts
+++ b/src/app/v5/shared/shared.module.ts
@@ -1,25 +1,30 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
 import { SeasonSelectorComponent } from './components/season-selector/season-selector.component';
 import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { ErrorMessageComponent } from './components/error-message/error-message.component';
 import { DataTableComponent } from './components/data-table/data-table.component';
+import { FormFieldComponent } from './forms/form-field.component';
 
 @NgModule({
   declarations: [
     SeasonSelectorComponent,
     LoadingSpinnerComponent,
     ErrorMessageComponent,
-    DataTableComponent
+    DataTableComponent,
+    FormFieldComponent
   ],
   imports: [
-    CommonModule
+    CommonModule,
+    ReactiveFormsModule
   ],
   exports: [
     SeasonSelectorComponent,
     LoadingSpinnerComponent,
     ErrorMessageComponent,
-    DataTableComponent
+    DataTableComponent,
+    FormFieldComponent
   ]
 })
 export class SharedModule {}


### PR DESCRIPTION
## Summary
- add `form-field` wrapper component
- expose validators and a `FormBuilderService`
- import `ReactiveFormsModule` in feature modules
- wire example forms to use the helpers

## Testing
- `node node_modules/@angular/cli/bin/ng test --watch=false` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6888e5f34970832097fae74e53c6a4b2