### PR TITLE
Persist payment provider and select gateway via SchoolService

### DIFF
--- a/src/@vex/components/aio-table/aio-table.component.ts
+++ b/src/@vex/components/aio-table/aio-table.component.ts
@@ -38,6 +38,7 @@ import * as QRCode from 'qrcode';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ExcelExportService } from '../../../service/excel.service';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { SchoolService } from 'src/service/school.service';
 
 @UntilDestroy()
 @Component({
@@ -146,7 +147,8 @@ export class AioTableComponent implements OnInit, AfterViewInit, OnChanges {
 
   constructor(private dialog: MatDialog, public router: Router, private crudService: ApiCrudService,
     private excelExportService: ExcelExportService, private routeActive: ActivatedRoute,
-    private cdr: ChangeDetectorRef, public translateService: TranslateService, private snackbar: MatSnackBar) {
+    private cdr: ChangeDetectorRef, public translateService: TranslateService, private snackbar: MatSnackBar,
+    private schoolService: SchoolService) {
     this.user = JSON.parse(localStorage.getItem('boukiiUser'));
     this.schoolId = this.user.schools[0].id;
   }
@@ -832,7 +834,7 @@ export class AioTableComponent implements OnInit, AfterViewInit, OnChanges {
       case 1:
         return 'CASH';
       case 2:
-        return 'BOUKII PAY';
+        return this.schoolService.getPaymentProvider() === 'payyo' ? 'PAYYO' : 'BOUKII PAY';
       case 3:
         return 'ONLINE';
       case 4:

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -182,6 +182,10 @@ export class AppComponent {
     /**
      * Add your own routes here
      */
+    const provider = this.schoolService.getPaymentProvider();
+    const gatewayLabel = provider === 'payyo' ? 'Payyo' : 'Boukii Pay';
+    const gatewayRoute = provider === 'payyo' ? 'https://merchant.payyo.ch/' : 'https://login.pay.boukii.com/fr/';
+
     this.navigationService.items = [
       /*{
         type: 'link',
@@ -307,8 +311,8 @@ export class AppComponent {
         children: [
           {
             type: "link",
-            label: "Boukii Pay",
-            route: "https://login.pay.boukii.com/fr/",
+            label: gatewayLabel,
+            route: gatewayRoute,
             icon: "../assets/img/icons/boukii_pay.svg",
             routerLinkActiveOptions: { exact: true },
           },

--- a/src/app/pages/bookings-v2/booking-detail/booking-detail.component.ts
+++ b/src/app/pages/bookings-v2/booking-detail/booking-detail.component.ts
@@ -12,6 +12,7 @@ import {
 } from '../../bookings/cancel-partial-booking/cancel-partial-booking.component';
 import {CancelBookingModalComponent} from '../../bookings/cancel-booking/cancel-booking.component';
 import {BookingDetailDialogComponent} from './components/booking-dialog/booking-dialog.component';
+import { SchoolService } from 'src/service/school.service';
 
 @Component({
   selector: 'booking-detail-v2',
@@ -37,10 +38,11 @@ export class BookingDetailV2Component implements OnInit {
   step: number = 1;  // Paso inicial
   selectedPaymentOption: string = 'Tarjeta';
   isPaid = false;
+  paymentProviderLabel = this.schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay';
   paymentOptions: any[] = [
     { type: 'Tarjeta', value: 4, translation: this.translateService.instant('credit_card') },
     { type: 'Efectivo', value: 1,  translation: this.translateService.instant('payment_cash') },
-    { type: 'Boukii Pay', value: 2, translation: 'Boukii Pay' }
+    { type: this.paymentProviderLabel, value: 2, translation: this.paymentProviderLabel }
   ];
 
   private activitiesChangedSubject = new Subject<void>();
@@ -55,6 +57,7 @@ export class BookingDetailV2Component implements OnInit {
     private crudService: ApiCrudService,
     private router: Router,
     private snackBar: MatSnackBar,
+    private schoolService: SchoolService,
     @Optional() @Inject(MAT_DIALOG_DATA) public incData: any
   ) {
 
@@ -457,7 +460,7 @@ export class BookingDetailV2Component implements OnInit {
       // Mapear la opción seleccionada con el método de pago
       if (this.selectedPaymentOption === 'Efectivo') {
         bookingData.payment_method_id = 1;
-      } else if (this.selectedPaymentOption === 'Boukii Pay') {
+      } else if (this.selectedPaymentOption === this.paymentProviderLabel) {
         bookingData.payment_method_id = 2;
       } else if (this.selectedPaymentOption === 'Tarjeta') {
         bookingData.payment_method_id = 4;

--- a/src/app/pages/bookings-v2/booking-detail/components/booking-reservation-detail/booking-reservation-detail.component.html
+++ b/src/app/pages/bookings-v2/booking-detail/components/booking-reservation-detail/booking-reservation-detail.component.html
@@ -337,7 +337,7 @@
         </div>
         <div>
           <span class="discounted-price">
-              {{ payment.status | translate }} - {{ payment.notes ?? 'Boukii Pay' | translate }}
+              {{ payment.status | translate }} - {{ (payment.notes ?? (schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay')) | translate }}
           </span>
           <span class="price">
             {{ payment.amount }} {{activities[0]?.course?.currency}}

--- a/src/app/pages/bookings-v2/booking-detail/components/booking-reservation-detail/booking-reservation-detail.component.ts
+++ b/src/app/pages/bookings-v2/booking-detail/components/booking-reservation-detail/booking-reservation-detail.component.ts
@@ -14,6 +14,7 @@ import {Router} from '@angular/router';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {TranslateService} from '@ngx-translate/core';
 import {ApiCrudService} from '../../../../../../service/crud.service';
+import { SchoolService } from 'src/service/school.service';
 
 @Component({
   selector: 'booking-detail-reservation-detail',
@@ -51,7 +52,8 @@ export class BookingReservationDetailComponent implements OnInit {
     private translateService: TranslateService,
     private router: Router,
     private dialog: MatDialog,
-    private bookingService: BookingService
+    private bookingService: BookingService,
+    public schoolService: SchoolService
   ) {
     this.school = this.utilsService.getSchoolData();
     this.settings = JSON.parse(this.school.settings);

--- a/src/app/pages/bookings-v2/bookings-create-update/bookings-create-update.component.ts
+++ b/src/app/pages/bookings-v2/bookings-create-update/bookings-create-update.component.ts
@@ -8,6 +8,7 @@ import {ApiCrudService} from '../../../../service/crud.service';
 import {Router} from '@angular/router';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import moment from 'moment';
+import { SchoolService } from 'src/service/school.service';
 
 @Component({
   selector: "bookings-create-update-v2",
@@ -45,10 +46,11 @@ export class BookingsCreateUpdateV2Component {
   selectedPaymentOption: string = 'Tarjeta';
   isPaid = false;
   isConfirmingPayment = false;
+  paymentProviderLabel = this.schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay';
   paymentOptions: any[] = [
     { type: 'Tarjeta', value: 4, translation: this.translateService.instant('credit_card') },
     { type: 'Efectivo', value: 1,  translation: this.translateService.instant('payment_cash') },
-    { type: 'Boukii Pay', value: 2, translation: 'Boukii Pay' }
+    { type: this.paymentProviderLabel, value: 2, translation: this.paymentProviderLabel }
   ]; // Opciones de pago para "Pago directo"
 
   constructor(
@@ -60,6 +62,7 @@ export class BookingsCreateUpdateV2Component {
     private crudService: ApiCrudService,
     private router: Router,
     private snackBar: MatSnackBar,
+    private schoolService: SchoolService,
     @Optional() public dialogRef: MatDialogRef<BookingsCreateUpdateV2Component>,
     @Optional() @Inject(MAT_DIALOG_DATA) public externalData: any
   ) {
@@ -653,7 +656,7 @@ export class BookingsCreateUpdateV2Component {
       // Mapear la opción seleccionada con el método de pago
       if (this.selectedPaymentOption === 'Efectivo') {
         bookingData.payment_method_id = 1;
-      } else if (this.selectedPaymentOption === 'Boukii Pay') {
+      } else if (this.selectedPaymentOption === this.paymentProviderLabel) {
         bookingData.payment_method_id = 2;
       } else if (this.selectedPaymentOption === 'Tarjeta') {
         bookingData.payment_method_id = 4;

--- a/src/app/pages/bookings-v2/bookings.component.ts
+++ b/src/app/pages/bookings-v2/bookings.component.ts
@@ -387,7 +387,7 @@ export class BookingsV2Component {
       case 1:
         return 'CASH';
       case 2:
-        return 'BOUKII PAY';
+        return this.schoolService.getPaymentProvider() === 'payyo' ? 'PAYYO' : 'BOUKII PAY';
       case 3:
         return 'ONLINE';
       case 4:

--- a/src/app/pages/bookings/booking-detail/booking-detail.component.html
+++ b/src/app/pages/bookings/booking-detail/booking-detail.component.html
@@ -1360,11 +1360,11 @@
                   " mat-raised-button color="accent" class="square-button">
 									{{ "payment_other" | translate }}
 								</button>
-								<button [class.selected]="selectedSubButton === '3'" (click)="
+                                                                <button [class.selected]="selectedSubButton === '3'" (click)="
                     selectedSubButton = '3'; defaults.payment_method_id = 2
                   " mat-raised-button color="accent" class="square-button">
-									Boukii Pay
-								</button>
+                                                                        {{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}
+                                                                </button>
 							</div>
 							<mat-divider *ngIf="selectedSubButton === '1' || selectedSubButton === '2'"
 								class="text-border" style="margin: 10px 0 10px 0"></mat-divider>

--- a/src/app/pages/bookings/booking-detail/booking-detail.component.ts
+++ b/src/app/pages/bookings/booking-detail/booking-detail.component.ts
@@ -231,7 +231,7 @@ export class BookingDetailComponent implements OnInit {
     private bookingService: BookingService,
     private snackbar: MatSnackBar,
     private activatedRoute: ActivatedRoute,
-    private schoolService: SchoolService,
+    public schoolService: SchoolService,
     private router: Router,
     public translateService: TranslateService,
     private dateAdapter: DateAdapter<Date>,

--- a/src/app/pages/bookings/bookings-create-update-edit/bookings-create-update-edit.component.html
+++ b/src/app/pages/bookings/bookings-create-update-edit/bookings-create-update-edit.component.html
@@ -2786,7 +2786,7 @@
                 [class.selected]="selectedSubButton==='3'"
                 *ngIf="(bookingService.editData.price - finalPrice) > 0"
               >
-                Boukii Pay
+                {{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}
               </button>
             </div>-->
             <!--            <mat-divider

--- a/src/app/pages/bookings/bookings-create-update-edit/bookings-create-update-edit.component.ts
+++ b/src/app/pages/bookings/bookings-create-update-edit/bookings-create-update-edit.component.ts
@@ -27,6 +27,7 @@ import { MatSelectChange } from '@angular/material/select';
 import { AddDiscountBonusModalComponent } from '../bookings-create-update/add-discount-bonus/add-discount-bonus.component';
 import { AddReductionModalComponent } from '../bookings-create-update/add-reduction/add-reduction.component';
 import { BookingService } from 'src/service/bookings.service';
+import { SchoolService } from 'src/service/school.service';
 import { ConfirmModalEditBookingComponent } from './confirm-dialog-edit-booking/confirm-dialog-edit-booking.component';
 @Injectable()
 @Component({
@@ -275,7 +276,8 @@ export class BookingsCreateUpdateEditComponent implements OnInit {
   private subscription: Subscription;
 
   constructor(private fb: UntypedFormBuilder, private dialog: MatDialog, private crudService: ApiCrudService, private calendarService: CalendarService,
-    private snackbar: MatSnackBar, private passwordGen: PasswordService, private router: Router, public translateService: TranslateService, public bookingService: BookingService) {
+    private snackbar: MatSnackBar, private passwordGen: PasswordService, private router: Router, public translateService: TranslateService, public bookingService: BookingService,
+    public schoolService: SchoolService) {
 
     this.minDate = new Date(); // Establecer la fecha mínima como la fecha actual
     this.subscription = this.calendarService.monthChanged$.subscribe(firstDayOfMonth => {

--- a/src/app/pages/bookings/bookings-create-update-modal/bookings-create-update-modal.component.html
+++ b/src/app/pages/bookings/bookings-create-update-modal/bookings-create-update-modal.component.html
@@ -1331,7 +1331,7 @@
                 <button mat-raised-button color="accent" class="square-button"
                   (click)="selectedSubButton='3'; defaults.payment_method_id = 2"
                   [class.selected]="selectedSubButton==='3'">
-                  Boukii Pay
+                  {{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}
                 </button>
               </div>
               <mat-divider *ngIf="selectedSubButton==='1' || selectedSubButton==='2'" class="text-border"

--- a/src/app/pages/bookings/bookings-create-update-modal/bookings-create-update-modal.component.ts
+++ b/src/app/pages/bookings/bookings-create-update-modal/bookings-create-update-modal.component.ts
@@ -25,6 +25,7 @@ import { MatSelectChange } from '@angular/material/select';
 import { AddReductionModalComponent } from '../bookings-create-update/add-reduction/add-reduction.component';
 import { AddDiscountBonusModalComponent } from '../bookings-create-update/add-discount-bonus/add-discount-bonus.component';
 import { TranslateService } from '@ngx-translate/core';
+import { SchoolService } from 'src/service/school.service';
 @Injectable()
 @Component({
   selector: 'custom-header-update-modal',
@@ -270,7 +271,7 @@ export class BookingsCreateUpdateModalComponent implements OnInit {
   private subscription: Subscription;
 
   constructor(private fb: UntypedFormBuilder, private dialog: MatDialog, private crudService: ApiCrudService, private calendarService: CalendarService, private dialogRef: MatDialogRef<any>,
-    private snackbar: MatSnackBar, private passwordGen: PasswordService, private router: Router, public translateService: TranslateService, @Inject(MAT_DIALOG_DATA) public externalData: any) {
+    private snackbar: MatSnackBar, private passwordGen: PasswordService, private router: Router, public translateService: TranslateService, public schoolService: SchoolService, @Inject(MAT_DIALOG_DATA) public externalData: any) {
 
     this.minDate = new Date(); // Establecer la fecha mínima como la fecha actual
     this.subscription = this.calendarService.monthChanged$.subscribe(firstDayOfMonth => {

--- a/src/app/pages/bookings/bookings-create-update/bookings-create-update.component.html
+++ b/src/app/pages/bookings/bookings-create-update/bookings-create-update.component.html
@@ -2308,7 +2308,7 @@
                 <button mat-raised-button color="accent" class="square-button"
                   (click)="selectedSubButton='3'; defaults.payment_method_id = 2"
                   [class.selected]="selectedSubButton==='3'">
-                  Boukii Pay
+                  {{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}
                 </button>
               </div>
 

--- a/src/app/pages/bookings/bookings-create-update/bookings-create-update.component.ts
+++ b/src/app/pages/bookings/bookings-create-update/bookings-create-update.component.ts
@@ -31,6 +31,7 @@ import { MOCK_COUNTRIES } from 'src/app/static-data/countries-data';
 import { AddClientSportModalComponent } from '../add-client-sport/add-client-sport.component';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
+import { SchoolService } from 'src/service/school.service';
 
 @Injectable()
 @Component({
@@ -281,7 +282,7 @@ export class BookingsCreateUpdateComponent implements OnInit {
   constructor(private fb: UntypedFormBuilder, private dialog: MatDialog, private crudService: ApiCrudService, private calendarService: CalendarService,
     private snackbar: MatSnackBar, private passwordGen: PasswordService, private router: Router,
     public translateService: TranslateService, private cdr: ChangeDetectorRef,
-    private dateAdapter: DateAdapter<Date>,
+    private dateAdapter: DateAdapter<Date>, public schoolService: SchoolService,
     @Optional() public dialogRef: MatDialogRef<BookingsCreateUpdateComponent>,
     @Optional() @Inject(MAT_DIALOG_DATA) public externalData: any) {
     this.dateAdapter.setLocale(this.translateService.getDefaultLang());

--- a/src/app/pages/bookings/bookings.component.ts
+++ b/src/app/pages/bookings/bookings.component.ts
@@ -374,7 +374,7 @@ export class BookingsComponent {
       case 1:
         return 'CASH';
       case 2:
-        return 'BOUKII PAY';
+        return this.schoolService.getPaymentProvider() === 'payyo' ? 'PAYYO' : 'BOUKII PAY';
       case 3:
         return 'ONLINE';
       case 4:

--- a/src/app/pages/bookings/cancel-booking/cancel-booking.component.html
+++ b/src/app/pages/bookings/cancel-booking/cancel-booking.component.html
@@ -41,7 +41,7 @@
       [disabled]="!defaults.booking.paid">
 
       <mat-tab-group>
-        <mat-tab label="Boukii Pay">
+        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay'">
 
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">

--- a/src/app/pages/bookings/cancel-booking/cancel-booking.component.ts
+++ b/src/app/pages/bookings/cancel-booking/cancel-booking.component.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable, map, startWith } from 'rxjs';
 import { ApiCrudService } from 'src/service/crud.service';
+import { SchoolService } from 'src/service/school.service';
 
 @Component({
   selector: 'vex-cancel-booking',
@@ -22,7 +23,7 @@ export class CancelBookingModalComponent implements OnInit {
   bonusForm: FormGroup;
 
   constructor(@Inject(MAT_DIALOG_DATA) public defaults: any, private crudService: ApiCrudService, private snackbar: MatSnackBar,
-    private fb: UntypedFormBuilder, private dialogRef: MatDialogRef<any>) {
+    private fb: UntypedFormBuilder, private dialogRef: MatDialogRef<any>, public schoolService: SchoolService) {
 
   }
 

--- a/src/app/pages/bookings/cancel-partial-booking/cancel-partial-booking.component.html
+++ b/src/app/pages/bookings/cancel-partial-booking/cancel-partial-booking.component.html
@@ -29,7 +29,7 @@
     <!-- Pestaña Refund -->
     <mat-tab label="{{'bookings_page.cancelations.refund' | translate}}">
       <mat-tab-group>
-        <mat-tab label="Boukii Pay">
+        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay'">
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">
               <p *ngIf="defaults.booking.payrexx_reference !== null">{{'bookings_page.cancelations.refund_boukiipay_text' | translate }}: <span style="color:#fe3085">{{defaults.itemPrice}} {{defaults.booking.currency}}</span></p>

--- a/src/app/pages/bookings/cancel-partial-booking/cancel-partial-booking.component.ts
+++ b/src/app/pages/bookings/cancel-partial-booking/cancel-partial-booking.component.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable, map, startWith } from 'rxjs';
 import { ApiCrudService } from 'src/service/crud.service';
+import { SchoolService } from 'src/service/school.service';
 
 @Component({
   selector: 'vex-cancel-partial-booking',
@@ -22,7 +23,7 @@ export class CancelPartialBookingModalComponent implements OnInit {
   bonusForm: FormGroup;
 
   constructor(@Inject(MAT_DIALOG_DATA) public defaults: any, private crudService: ApiCrudService, private snackbar: MatSnackBar,
-    private fb: UntypedFormBuilder, private dialogRef: MatDialogRef<any>) {
+    private fb: UntypedFormBuilder, private dialogRef: MatDialogRef<any>, public schoolService: SchoolService) {
 
   }
 

--- a/src/app/pages/bookings/refund-booking/refund-booking.component.html
+++ b/src/app/pages/bookings/refund-booking/refund-booking.component.html
@@ -34,7 +34,7 @@
       <ng-template matStepLabel>{{'bookings_page.cancelations.refund' | translate }}</ng-template>
 
       <mat-tab-group>
-        <mat-tab label="Boukii Pay">
+        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay'">
 
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">

--- a/src/app/pages/bookings/refund-booking/refund-booking.component.ts
+++ b/src/app/pages/bookings/refund-booking/refund-booking.component.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable, map, startWith } from 'rxjs';
 import { ApiCrudService } from 'src/service/crud.service';
+import { SchoolService } from 'src/service/school.service';
 
 @Component({
   selector: 'vex-refund-booking',
@@ -22,7 +23,7 @@ export class RefundBookingModalComponent implements OnInit {
   bonusForm: FormGroup;
 
   constructor(@Inject(MAT_DIALOG_DATA) public defaults: any, private crudService: ApiCrudService, private snackbar: MatSnackBar,
-    private fb: UntypedFormBuilder, private dialogRef: MatDialogRef<any>) {
+    private fb: UntypedFormBuilder, private dialogRef: MatDialogRef<any>, public schoolService: SchoolService) {
 
   }
 

--- a/src/app/pages/clients/client-detail/client-detail.component.ts
+++ b/src/app/pages/clients/client-detail/client-detail.component.ts
@@ -24,6 +24,7 @@ import { TableColumn } from 'src/@vex/interfaces/table-column.interface';
 import { TranslateService } from '@ngx-translate/core';
 import { DateAdapter } from '@angular/material/core';
 import { switchMap } from 'rxjs/operators';
+import { SchoolService } from 'src/service/school.service';
 
 
 @Component({
@@ -182,7 +183,7 @@ export class ClientDetailComponent {
 
   constructor(private fb: UntypedFormBuilder, private cdr: ChangeDetectorRef, private crudService: ApiCrudService, private router: Router,
               private activatedRoute: ActivatedRoute, private snackbar: MatSnackBar, private dialog: MatDialog, private passwordGen: PasswordService,
-              private translateService: TranslateService, private dateAdapter: DateAdapter<Date>) {
+              private translateService: TranslateService, private dateAdapter: DateAdapter<Date>, private schoolService: SchoolService) {
     this.today = new Date();
     this.minDate = new Date(this.today);
     this.minDate.setFullYear(this.today.getFullYear() - 18);
@@ -1184,7 +1185,7 @@ export class ClientDetailComponent {
       case 1:
         return 'CASH';
       case 2:
-        return 'BOUKII PAY';
+        return this.schoolService.getPaymentProvider() === 'payyo' ? 'PAYYO' : 'BOUKII PAY';
       case 3:
         return 'ONLINE';
       case 4:

--- a/src/app/pages/courses/course-detail/course-detail.component.ts
+++ b/src/app/pages/courses/course-detail/course-detail.component.ts
@@ -14,6 +14,7 @@ import { ConfirmModalComponent } from '../../monitors/monitor-detail/confirm-dia
 import { TranslateService } from '@ngx-translate/core';
 import { TableColumn } from 'src/@vex/interfaces/table-column.interface';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { SchoolService } from 'src/service/school.service';
 
 @Component({
   selector: 'vex-course-detail',
@@ -155,7 +156,7 @@ export class CourseDetailComponent implements OnInit {
   ];
 
   constructor(private fb: UntypedFormBuilder, private crudService: ApiCrudService, private activatedRoute: ActivatedRoute, private router: Router, private dialog: MatDialog,
-              private snackbar: MatSnackBar, private translateService: TranslateService, private sanitizer: DomSanitizer) {
+              private snackbar: MatSnackBar, private translateService: TranslateService, private sanitizer: DomSanitizer, private schoolService: SchoolService) {
     this.user = JSON.parse(localStorage.getItem('boukiiUser'));
     this.settings = JSON.parse(this.user.schools[0].settings);
     this.id = this.activatedRoute.snapshot.params.id;
@@ -310,7 +311,7 @@ export class CourseDetailComponent implements OnInit {
       case 1:
         return 'CASH';
       case 2:
-        return 'BOUKII PAY';
+        return this.schoolService.getPaymentProvider() === 'payyo' ? 'PAYYO' : 'BOUKII PAY';
       case 3:
         return 'ONLINE';
       case 4:

--- a/src/service/school.service.ts
+++ b/src/service/school.service.ts
@@ -19,18 +19,37 @@ export class SchoolService {
     this.crudService.get('/schools/'+this.user.schools[0].id)
       .subscribe((data) => {
         this.schoolSettings = data.data;
+        if (data.data && data.data.payment_provider) {
+          localStorage.setItem('paymentProvider', data.data.payment_provider);
+        }
       })
   }
 
   getSchoolData(user = null, forceParam = false) {
     this.user = JSON.parse(localStorage.getItem('boukiiUser'));
     if (this.user && !forceParam) {
-
-      return this.crudService.get('/schools/'+this.user.schools[0].id);
+      return this.crudService.get('/schools/'+this.user.schools[0].id).pipe(
+        tap((res: any) => {
+          if (res.data && res.data.payment_provider) {
+            localStorage.setItem('paymentProvider', res.data.payment_provider);
+          }
+        })
+      );
     } else {
-      return this.crudService.get('/schools/'+user.schools[0].id);
+      return this.crudService.get('/schools/'+user.schools[0].id).pipe(
+        tap((res: any) => {
+          if (res.data && res.data.payment_provider) {
+            localStorage.setItem('paymentProvider', res.data.payment_provider);
+          }
+        })
+      );
 
     }
+  }
+
+  getPaymentProvider(): 'payrexx' | 'payyo' {
+    const provider = localStorage.getItem('paymentProvider');
+    return provider === 'payyo' ? 'payyo' : 'payrexx';
   }
 }
 


### PR DESCRIPTION
## Summary
- persist payment provider from school data and expose a getPaymentProvider helper
- use getPaymentProvider across booking flows and navigation to choose Payrexx or Payyo

## Testing
- `npm test` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b06fc528688320bd8d5d1f0a1e42ac