### PR TITLE
refactor: dynamic refund log actions

### DIFF
--- a/src/app/pages/bookings-v2/bookings.component.html
+++ b/src/app/pages/bookings-v2/bookings.component.html
@@ -584,9 +584,9 @@
                   {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:
                   {{'refund_cash' | translate }}
                 </p>
-                <p style="float:left" *ngIf="item.action == 'voucher_refund'">
+                <p style="float:left" *ngIf="item.action == 'refund_voucher'">
                   {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:
-                  {{'voucher_refund' | translate }}
+                  {{'refund_voucher' | translate }}
                 </p>
                 <p style="float:left" *ngIf="item.action == 'update'">
                   {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:

--- a/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.html
+++ b/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.html
@@ -689,8 +689,8 @@
                     date: 'dd-MM-yyyy hh:mm:ss'}}: {{'refund_cash' | translate
                     }}</p>
                   <p style="float:left"
-                    *ngIf="item.action == 'voucher_refund'">{{item.created_at |
-                    date: 'dd-MM-yyyy hh:mm:ss'}}: {{'voucher_refund' |
+                    *ngIf="item.action == 'refund_voucher'">{{item.created_at |
+                    date: 'dd-MM-yyyy hh:mm:ss'}}: {{'refund_voucher' |
                     translate }}</p>
                   <p style="float:left"
                     *ngIf="item.action == 'update'">{{item.created_at | date:

--- a/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.ts
+++ b/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.ts
@@ -1656,7 +1656,8 @@ export class BookingDetailModalComponent implements OnInit {
 
         } else if(data.type === 'boukii_pay') {
 
-          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_boukii_pay', before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
+          const provider = data.type;
+          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_' + provider, before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
           .subscribe(() => {
             this.crudService.update('/bookings', {paid_total: this.booking.price_total}, this.booking.id)
             .subscribe(() => {
@@ -1670,7 +1671,9 @@ export class BookingDetailModalComponent implements OnInit {
 
         } else if(data.type === 'refund') {
 
-          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund', before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
+          const provider = 'cash';
+
+          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_' + provider, before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
           .subscribe(() => {
             this.crudService.update('/bookings', {paid_total: this.booking.price_total}, this.booking.id)
             .subscribe(() => {
@@ -1694,7 +1697,8 @@ export class BookingDetailModalComponent implements OnInit {
             school_id: this.user.schools[0].id
           };
 
-          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'voucher_refund', before_change: 'confirmed', user_id: this.user.id})
+          const provider = 'voucher';
+          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_' + provider, before_change: 'confirmed', user_id: this.user.id})
           .subscribe(() => {
             this.crudService.update('/bookings', {paid_total: this.booking.price_total}, this.booking.id)
             .subscribe(() => {
@@ -1757,7 +1761,8 @@ export class BookingDetailModalComponent implements OnInit {
           })
         } else if(data.type === 'boukii_pay') {
 
-          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_boukii_pay', before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
+          const provider = data.type;
+          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_' + provider, before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
           .subscribe(() => {
             this.crudService.update('/bookings', {paid_total: this.booking.price_total}, this.booking.id)
             .subscribe(() => {
@@ -1784,7 +1789,8 @@ export class BookingDetailModalComponent implements OnInit {
 
         } else if(data.type === 'refund') {
 
-          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_cash', before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
+          const provider = 'cash';
+          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_' + provider, before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
           .subscribe(() => {
 
             this.crudService.create('/payments', {booking_id: this.id, school_id: this.user.schools[0].id, amount: this.finalPrice, status: 'refund', notes: 'other'})
@@ -1815,7 +1821,8 @@ export class BookingDetailModalComponent implements OnInit {
             school_id: this.user.schools[0].id
           };
 
-          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'voucher_refund', before_change: 'confirmed', user_id: this.user.id})
+          const provider = 'voucher';
+          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_' + provider, before_change: 'confirmed', user_id: this.user.id})
           .subscribe(() => {
             this.crudService.update('/bookings', {status: 2}, this.booking.id)
             .subscribe(() => {
@@ -1907,7 +1914,8 @@ export class BookingDetailModalComponent implements OnInit {
 
         } else if(data.type === 'boukii_pay') {
 
-          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_boukii_pay', before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
+          const provider = data.type;
+          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_' + provider, before_change: 'confirmed', user_id: this.user.id, reason: data.reason})
           .subscribe(() => {
             this.crudService.update('/bookings', {paid_total: this.booking.price_total}, this.booking.id)
             .subscribe(() => {
@@ -1935,7 +1943,8 @@ export class BookingDetailModalComponent implements OnInit {
 
         } else if(data.type === 'refund') {
 
-          this.crudService.create('/booking-logs', {booking_id: this.id, action:'refund_cash', before_change: 'confirmed', user_id: this.user.id, description: data.reason})
+          const provider = 'cash';
+          this.crudService.create('/booking-logs', {booking_id: this.id, action:'refund_' + provider, before_change: 'confirmed', user_id: this.user.id, description: data.reason})
           .subscribe(() => {
             this.crudService.create('/payments', {booking_id: this.id, school_id: this.user.schools[0].id, amount: this.bookingsToCreate[index].price_total, status: 'refund', notes: 'other'})
             .subscribe(() => {
@@ -1962,7 +1971,8 @@ export class BookingDetailModalComponent implements OnInit {
             client_id: this.booking.client_main_id,
             school_id: this.user.schools[0].id
           };
-          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'voucher_refund', before_change: 'confirmed', user_id: this.user.id})
+          const provider = 'voucher';
+          this.crudService.create('/booking-logs', {booking_id: this.id, action: 'refund_' + provider, before_change: 'confirmed', user_id: this.user.id})
           .subscribe(() => {
             book.courseDates.forEach(element => {
               this.crudService.update('/booking-users', {status:2}, element.id)

--- a/src/app/pages/bookings/booking-detail/booking-detail.component.html
+++ b/src/app/pages/bookings/booking-detail/booking-detail.component.html
@@ -1315,13 +1315,13 @@
 									{{ "refund_cash" | translate }}
 								</div>
 							</div>
-							<div *ngIf="item.action == 'voucher_refund'">
-								<div class="list-box">
-									{{ item.created_at | date: "dd-MM-yyyy hh:mm:ss" }}:
-									<br>
-									{{ "voucher_refund" | translate }}
-								</div>
-							</div>
+                                                        <div *ngIf="item.action == 'refund_voucher'">
+                                                                <div class="list-box">
+                                                                        {{ item.created_at | date: "dd-MM-yyyy hh:mm:ss" }}:
+                                                                        <br>
+                                                                        {{ "refund_voucher" | translate }}
+                                                                </div>
+                                                        </div>
 							<div *ngIf="item.action == 'update'">
 								<div class="list-box">
 									{{ item.created_at | date: "dd-MM-yyyy hh:mm:ss" }}:

--- a/src/app/pages/bookings/booking-detail/booking-detail.component.ts
+++ b/src/app/pages/bookings/booking-detail/booking-detail.component.ts
@@ -1972,10 +1972,11 @@ export class BookingDetailComponent implements OnInit {
               this.getData();
             });
         } else if (data.type === "boukii_pay") {
+          const provider = data.type;
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "refund_boukii_pay",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
               reason: data.reason,
@@ -2005,10 +2006,11 @@ export class BookingDetailComponent implements OnInit {
                 });
             });
         } else if (data.type === "refund") {
+          const provider = "cash";
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "refund",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
               reason: data.reason,
@@ -2051,10 +2053,11 @@ export class BookingDetailComponent implements OnInit {
             school_id: this.user.schools[0].id,
           };
 
+          const provider = "voucher";
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "voucher_refund",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
             })
@@ -2167,10 +2170,11 @@ export class BookingDetailComponent implements OnInit {
                 });
             });
         } else if (data.type === "boukii_pay") {
+          const provider = data.type;
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "refund_boukii_pay",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
               reason: data.reason,
@@ -2217,10 +2221,11 @@ export class BookingDetailComponent implements OnInit {
               }
             });
         } else if (data.type === "refund") {
+          const provider = "cash";
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "refund_cash",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
               reason: data.reason,
@@ -2268,10 +2273,11 @@ export class BookingDetailComponent implements OnInit {
             school_id: this.user.schools[0].id,
           };
 
+          const provider = "voucher";
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "voucher_refund",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
             })
@@ -2450,10 +2456,11 @@ export class BookingDetailComponent implements OnInit {
             { duration: 3000 }
           );
         } else if (data.type === "boukii_pay") {
+          const provider = data.type;
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "refund_boukii_pay",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
               reason: data.reason,
@@ -2499,10 +2506,11 @@ export class BookingDetailComponent implements OnInit {
 
             });
         } else if (data.type === "refund") {
+          const provider = "cash";
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "refund_cash",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
               description: data.reason,
@@ -2544,10 +2552,11 @@ export class BookingDetailComponent implements OnInit {
             client_id: this.booking.client_main_id,
             school_id: this.user.schools[0].id,
           };
+          const provider = "voucher";
           this.crudService
             .create("/booking-logs", {
               booking_id: this.id,
-              action: "voucher_refund",
+              action: "refund_" + provider,
               before_change: "confirmed",
               user_id: this.user.id,
             })

--- a/src/app/pages/bookings/bookings.component.html
+++ b/src/app/pages/bookings/bookings.component.html
@@ -590,9 +590,9 @@
                   {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:
                   {{'refund_cash' | translate }}
                 </p>
-                <p style="float:left" *ngIf="item.action == 'voucher_refund'">
+                <p style="float:left" *ngIf="item.action == 'refund_voucher'">
                   {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:
-                  {{'voucher_refund' | translate }}
+                  {{'refund_voucher' | translate }}
                 </p>
                 <p style="float:left" *ngIf="item.action == 'update'">
                   {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:

--- a/src/app/pages/clients/client-detail/client-detail.component.html
+++ b/src/app/pages/clients/client-detail/client-detail.component.html
@@ -1594,9 +1594,9 @@
                             {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:
                             {{'refund_cash' | translate }}
                           </p>
-                          <p style="float:left" *ngIf="item.action == 'voucher_refund'">
+                          <p style="float:left" *ngIf="item.action == 'refund_voucher'">
                             {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:
-                            {{'voucher_refund' | translate }}
+                            {{'refund_voucher' | translate }}
                           </p>
                           <p style="float:left" *ngIf="item.action == 'update'">
                             {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:

--- a/src/app/pages/courses/course-detail/course-detail.component.html
+++ b/src/app/pages/courses/course-detail/course-detail.component.html
@@ -1105,9 +1105,9 @@
                           {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:
                           {{'refund_cash' | translate }}
                         </p>
-                        <p style="float:left" *ngIf="item.action == 'voucher_refund'">
+                        <p style="float:left" *ngIf="item.action == 'refund_voucher'">
                           {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:
-                          {{'voucher_refund' | translate }}
+                          {{'refund_voucher' | translate }}
                         </p>
                         <p style="float:left" *ngIf="item.action == 'update'">
                           {{item.created_at | date: 'dd-MM-yyyy hh:mm:ss'}}:

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -606,7 +606,7 @@
   "partial_cancel": "Teilstornierung",
   "cancel_no_refund": "Stornierung ohne Rückerstattung",
   "refund_cash": "Barzahlung oder andere Rückerstattung",
-  "voucher_refund": "Rückerstattung mit Bonus",
+  "refund_voucher": "Rückerstattung mit Bonus",
   "deactivate": "Deaktivieren",
   "activate": "Aktivieren",
   "monitor_comments": "Überwachen Sie Kommentare",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -612,7 +612,7 @@
   "partial_cancel": "Partial cancelation",
   "cancel_no_refund": "Cancellation without refund",
   "refund_cash": "Cash or other refund",
-  "voucher_refund": "Refund with bonus",
+  "refund_voucher": "Refund with bonus",
   "deactivate": "Deactivate",
   "activate": "Activate",
   "monitor_comments": "Monitor Comments",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -636,7 +636,7 @@
   "partial_cancel": "Cancelación parcial",
   "cancel_no_refund": "Cancelación sin reembolso",
   "refund_cash": "Reembolso en efectivo u otros",
-  "voucher_refund": "Reembolso con bono",
+  "refund_voucher": "Reembolso con bono",
   "deactivate": "Desactivar",
   "activate": "Activar",
   "monitor_comments": "Comentarios del monitor",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -610,7 +610,7 @@
   "partial_cancel": "Annulation partielle",
   "cancel_no_refund": "Annulation sans remboursement",
   "refund_cash": "Espèces ou autre remboursement",
-  "voucher_refund": "Remboursement avec bons",
+  "refund_voucher": "Remboursement avec bons",
   "deactivate": "Désactiver",
   "activate": "Activer",
   "monitor_comments": "Observations du moniteur.",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -604,7 +604,7 @@
   "partial_cancel": "Cancellazione parziale",
   "cancel_no_refund": "Cancellazione senza rimborso",
   "refund_cash": "Rimborso in contanti o altro",
-  "voucher_refund": "Rimborso con bonus",
+  "refund_voucher": "Rimborso con bonus",
   "deactivate": "Disattivare",
   "activate": "Attivare",
   "monitor_comments": "Monitorare i commenti",

--- a/src/service/bookings.service.ts
+++ b/src/service/bookings.service.ts
@@ -313,10 +313,11 @@ export class BookingService {
   }
 
   private handleBoukiiPay(bookingId: number, bookTotalPrice: number, bookingUsers: any[], userData: any, reason: string): Observable<any> {
+    const provider = 'boukii_pay';
     const operations: Observable<any>[] = [
       this.createBookingLog({
         booking_id: bookingId,
-        action: 'refund_boukii_pay',
+        action: 'refund_' + provider,
         before_change: 'confirmed',
         user_id: userData.id,
         reason: reason
@@ -338,10 +339,11 @@ export class BookingService {
   }
 
   private handleCashRefund(bookingId: number, bookingUsers: any[], bookTotalPrice: number, userData: any, reason: string): Observable<any> {
+    const provider = 'cash';
     const operations = [
       this.createBookingLog({
         booking_id: bookingId,
-        action: 'refund_cash',
+        action: 'refund_' + provider,
         before_change: 'confirmed',
         user_id: userData.id,
         description: reason
@@ -360,6 +362,7 @@ export class BookingService {
   }
 
   private handleVoucherRefund(bookingId: number, bookingUsers: any[], bookTotalPrice: number, userData: any, clientMainId: number): Observable<any> {
+    const provider = 'voucher';
     const voucherData: VoucherData = {
       code: 'BOU-' + this.generateRandomNumber(),
       quantity: bookTotalPrice,
@@ -372,7 +375,7 @@ export class BookingService {
     return forkJoin([
       this.createBookingLog({
         booking_id: bookingId,
-        action: 'voucher_refund',
+        action: 'refund_' + provider,
         before_change: 'confirmed',
         user_id: userData.id
       }),


### PR DESCRIPTION
## Summary
- log refunds with gateway-specific actions across booking flows
- rename voucher refund action to consistent `refund_voucher`

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Generating browser application bundles...)*

------
https://chatgpt.com/codex/tasks/task_e_68b14cc6da40832092c3fe97b5d05e80