### PR TITLE
feat: add Payyo translation

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -183,7 +183,7 @@ export class AppComponent {
      * Add your own routes here
      */
     const provider = this.schoolService.getPaymentProvider();
-    const gatewayLabel = provider === 'payyo' ? 'Payyo' : 'Boukii Pay';
+    const gatewayLabel = provider === 'payyo' ? this.translateService.instant('payment_payyo') : 'Boukii Pay';
     const gatewayRoute = provider === 'payyo' ? 'https://merchant.payyo.ch/' : 'https://login.pay.boukii.com/fr/';
 
     this.navigationService.items = [

--- a/src/app/pages/bookings-v2/booking-detail/booking-detail.component.ts
+++ b/src/app/pages/bookings-v2/booking-detail/booking-detail.component.ts
@@ -38,7 +38,9 @@ export class BookingDetailV2Component implements OnInit {
   step: number = 1;  // Paso inicial
   selectedPaymentOption: string = 'Tarjeta';
   isPaid = false;
-  paymentProviderLabel = this.schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay';
+  paymentProviderLabel = this.schoolService.getPaymentProvider() === 'payyo'
+    ? this.translateService.instant('payment_payyo')
+    : 'Boukii Pay';
   paymentOptions: any[] = [
     { type: 'Tarjeta', value: 4, translation: this.translateService.instant('credit_card') },
     { type: 'Efectivo', value: 1,  translation: this.translateService.instant('payment_cash') },

--- a/src/app/pages/bookings-v2/booking-detail/components/booking-reservation-detail/booking-reservation-detail.component.html
+++ b/src/app/pages/bookings-v2/booking-detail/components/booking-reservation-detail/booking-reservation-detail.component.html
@@ -337,7 +337,13 @@
         </div>
         <div>
           <span class="discounted-price">
-              {{ payment.status | translate }} - {{ (payment.notes ?? (schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay')) | translate }}
+              {{ payment.status | translate }} - {{
+                payment.notes
+                  ? (payment.notes | translate)
+                  : (schoolService.getPaymentProvider() === 'payyo'
+                      ? ('payment_payyo' | translate)
+                      : 'Boukii Pay')
+              }}
           </span>
           <span class="price">
             {{ payment.amount }} {{activities[0]?.course?.currency}}

--- a/src/app/pages/bookings-v2/bookings-create-update/bookings-create-update.component.ts
+++ b/src/app/pages/bookings-v2/bookings-create-update/bookings-create-update.component.ts
@@ -46,7 +46,9 @@ export class BookingsCreateUpdateV2Component {
   selectedPaymentOption: string = 'Tarjeta';
   isPaid = false;
   isConfirmingPayment = false;
-  paymentProviderLabel = this.schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay';
+  paymentProviderLabel = this.schoolService.getPaymentProvider() === 'payyo'
+    ? this.translateService.instant('payment_payyo')
+    : 'Boukii Pay';
   paymentOptions: any[] = [
     { type: 'Tarjeta', value: 4, translation: this.translateService.instant('credit_card') },
     { type: 'Efectivo', value: 1,  translation: this.translateService.instant('payment_cash') },

--- a/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.html
+++ b/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.html
@@ -730,7 +730,7 @@
                 <button mat-raised-button color="accent" class="square-button"
                   (click)="selectedSubButton='3'; defaults.payment_method_id = 2"
                   [class.selected]="selectedSubButton==='3'"
-                  [disabled]="booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] === null">{{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}</button>
+                  [disabled]="booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] === null">{{ schoolService.getPaymentProvider() === 'payyo' ? ('payment_payyo' | translate) : 'Boukii Pay' }}</button>
               </div>
               <mat-divider
                 *ngIf="selectedSubButton==='1' || selectedSubButton==='2'"

--- a/src/app/pages/bookings/booking-detail/booking-detail.component.html
+++ b/src/app/pages/bookings/booking-detail/booking-detail.component.html
@@ -1363,7 +1363,7 @@
                                                                 <button [class.selected]="selectedSubButton === '3'" (click)="
                     selectedSubButton = '3'; defaults.payment_method_id = 2
                   " mat-raised-button color="accent" class="square-button">
-                                                                        {{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}
+                                                                        {{ schoolService.getPaymentProvider() === 'payyo' ? ('payment_payyo' | translate) : 'Boukii Pay' }}
                                                                 </button>
 							</div>
 							<mat-divider *ngIf="selectedSubButton === '1' || selectedSubButton === '2'"

--- a/src/app/pages/bookings/bookings-create-update-edit/bookings-create-update-edit.component.html
+++ b/src/app/pages/bookings/bookings-create-update-edit/bookings-create-update-edit.component.html
@@ -2786,7 +2786,7 @@
                 [class.selected]="selectedSubButton==='3'"
                 *ngIf="(bookingService.editData.price - finalPrice) > 0"
               >
-                {{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}
+                {{ schoolService.getPaymentProvider() === 'payyo' ? ('payment_payyo' | translate) : 'Boukii Pay' }}
               </button>
             </div>-->
             <!--            <mat-divider

--- a/src/app/pages/bookings/bookings-create-update-modal/bookings-create-update-modal.component.html
+++ b/src/app/pages/bookings/bookings-create-update-modal/bookings-create-update-modal.component.html
@@ -1331,7 +1331,7 @@
                 <button mat-raised-button color="accent" class="square-button"
                   (click)="selectedSubButton='3'; defaults.payment_method_id = 2"
                   [class.selected]="selectedSubButton==='3'">
-                  {{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}
+                  {{ schoolService.getPaymentProvider() === 'payyo' ? ('payment_payyo' | translate) : 'Boukii Pay' }}
                 </button>
               </div>
               <mat-divider *ngIf="selectedSubButton==='1' || selectedSubButton==='2'" class="text-border"

--- a/src/app/pages/bookings/bookings-create-update/bookings-create-update.component.html
+++ b/src/app/pages/bookings/bookings-create-update/bookings-create-update.component.html
@@ -2308,7 +2308,7 @@
                 <button mat-raised-button color="accent" class="square-button"
                   (click)="selectedSubButton='3'; defaults.payment_method_id = 2"
                   [class.selected]="selectedSubButton==='3'">
-                  {{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}
+                  {{ schoolService.getPaymentProvider() === 'payyo' ? ('payment_payyo' | translate) : 'Boukii Pay' }}
                 </button>
               </div>
 

--- a/src/app/pages/bookings/cancel-booking/cancel-booking.component.html
+++ b/src/app/pages/bookings/cancel-booking/cancel-booking.component.html
@@ -41,7 +41,7 @@
       [disabled]="!defaults.booking.paid">
 
       <mat-tab-group>
-        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay'">
+        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? ('payment_payyo' | translate) : 'Boukii Pay'">
 
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">

--- a/src/app/pages/bookings/cancel-partial-booking/cancel-partial-booking.component.html
+++ b/src/app/pages/bookings/cancel-partial-booking/cancel-partial-booking.component.html
@@ -29,7 +29,7 @@
     <!-- Pestaña Refund -->
     <mat-tab label="{{'bookings_page.cancelations.refund' | translate}}">
       <mat-tab-group>
-        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay'">
+        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? ('payment_payyo' | translate) : 'Boukii Pay'">
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">
               <p *ngIf="defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] !== null">{{'bookings_page.cancelations.refund_boukiipay_text' | translate }}: <span style="color:#fe3085">{{defaults.itemPrice}} {{defaults.booking.currency}}</span></p>

--- a/src/app/pages/bookings/refund-booking/refund-booking.component.html
+++ b/src/app/pages/bookings/refund-booking/refund-booking.component.html
@@ -34,7 +34,7 @@
       <ng-template matStepLabel>{{'bookings_page.cancelations.refund' | translate }}</ng-template>
 
       <mat-tab-group>
-        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay'">
+        <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? ('payment_payyo' | translate) : 'Boukii Pay'">
 
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -198,6 +198,7 @@
   "payment_online": "Online",
   "payment_no_payment": "Bestätigen Sie ohne Zahlung",
   "payment_cash": "Kasse",
+  "payment_payyo": "Payyo",
   "other_info": "Andere Daten",
   "others": "Andere",
   "is_paid": "Hat der Kunde die Reservierung bezahlt?",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -206,6 +206,7 @@
   "payment_online": "Online",
   "payment_no_payment": "Confirm without payment",
   "payment_cash": "Cash",
+  "payment_payyo": "Payyo",
   "other_info": "Other data",
   "others": "Others",
   "is_paid": "Did the client pay for the reservation?",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -213,6 +213,7 @@
   "payment_online": "Online",
   "payment_no_payment": "Confirmación sin pago",
   "payment_cash": "Efectivo",
+  "payment_payyo": "Payyo",
   "payment_other": "Otro",
   "other_info": "Otros datos",
   "others": "Otros",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -206,6 +206,7 @@
   "payment_online": "En ligne",
   "payment_no_payment": "Confirmer sans paiement",
   "payment_cash": "Espèces",
+  "payment_payyo": "Payyo",
   "payment_other": "Autre",
   "other_info": "D'autres données",
   "others": "Autres",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -200,6 +200,7 @@
   "payment_online": "In linea",
   "payment_no_payment": "Conferma senza pagamento",
   "payment_cash": "Contanti",
+  "payment_payyo": "Payyo",
   "payment_other": "Altro",
   "other_info": "Altri dati",
   "others": "Altri",


### PR DESCRIPTION
## Summary
- add `payment_payyo` key to i18n files
- use Payyo translation when labeling payment provider

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68b1508fbc6c83209c4dbaee389762d4